### PR TITLE
Working Docker build and image for rye

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,6 +1,8 @@
-FROM golang:1.14
+FROM golang:1.14-alpine AS builder
 
-WORKDIR /src
+RUN apk add --no-cache git gtk+3.0 gtk+3.0-dev sqlite-dev bash gcc libc-dev
+
+WORKDIR /go/src/rye
 
 COPY . .
 
@@ -14,10 +16,12 @@ RUN go get -d -v -insecure \
     github.com/mattn/go-sqlite3 \
     github.com/nats-io/nats.go \
     github.com/shirou/gopsutil/mem \
-    github.com/tobgu/qframe
+    github.com/tobgu/qframe \
+    github.com/peterh/liner
 
 RUN mkdir -p /out && \
     go build -x -o /out/rye .
 
-FROM scratch AS bin
-COPY --from=build /out/rye /
+FROM alpine AS bin
+COPY --from=builder /out/rye /
+ENTRYPOINT ["/rye"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 _sandbox/
 .idea/
+rye

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Binaries for programs and plugins
 rye
-./rye
+
 *.exe
 *.exe~
 *.dll

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # rye 🌾
 
-> ⚠️ This is experimental programming language from [refaktor], looking into new (and borrowed) language ideas with interpreter in Go. ⚠️
+An experimental programming language from [refaktor], looking into new (and borrowed) language 
+ideas with interpreter in Go. ⚠
 
-You could peek at [NOTES.md](./NOTES.md), where concepts and ideas are born and logged. The language introduction documents are coming.
+## Progress
+You could peek at [NOTES.md](./NOTES.md), where concepts and ideas are born and logged. 
+The language [introduction documents](./INTRO_1.md) are coming.
 
 ## Development and experimentation
 
-Currently, tested on Linux and Mac.
+Currently, tested on Linux, Mac and Docker.
 
 ### Builds the rye interpreter
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ You could peek at [NOTES.md](./NOTES.md), where concepts and ideas are born and 
 
 ## Development and experimentation
 
-Currently tested on Linux and Mac.
+Currently, tested on Linux and Mac.
 
 ### Builds the rye interpreter
 
 ```bash
 go get -v github.com/pkg/profile \
   github.com/yhirose/go-peg \
-  github.com/mattn/go-sqlite3 \
+  github.com/mattn/go-sqlite3
  
 go build
 
@@ -43,6 +43,21 @@ go build -tags "b_echo b_gtk b_psql b_nats b_psutil b_qframe" -o ryefull
 ./ryefull 
 ```
 
+## Docker image
+
+The repository comes with [Docker image](./docker/Dockerfile) that is capable of building rye in its full, 
+the final step however then just wraps executable so that the image remains small and nimble.
+
+```bash
+docker build -t refaktor/rye -f .docker/Dockerfile .
+```
+
+Run 🏃‍♂️ the rye REPL with:
+
+```bash
+docker run -ti refaktor/rye
+```
+
 ## OSX tips
 
 Ryefull relies on GTK3. So make sure your machine has it.
@@ -52,15 +67,6 @@ brew install pkg-config gtk+3 adwaita-icon-theme
 ```
 
 More [instructions here](https://www.gtk.org/docs/installations/macos/).
-
-## Building Docker image
-
-```bash
-docker build -t refaktor/rye -f .docker/Dockerfile .
-```
-
-> Currently broken, because rye depends on GTK3 and few 
-> other things that are not part of original golang Docker image.  
 
 ## Author
 


### PR DESCRIPTION
I've managed to prepare the working image for rye that is split into two stages; build and "slim" part.

The instructions on how to build rye with docker and then run it were also added to README.md respectfully.

![Screenshot 2020-08-07 at 10 26 13](https://user-images.githubusercontent.com/225946/89625622-73f0a200-d898-11ea-8fac-499e32b5d6b2.png)

I've also removed the "warning" part from README.md - because life is to short to not live on the edge. ;)

Hope this will encourage some new ppl to experiment with this.

Cheers!

- Oto