### PR TITLE
Adding #not_equals operator

### DIFF
--- a/evaldo/builtins.go
+++ b/evaldo/builtins.go
@@ -65,7 +65,6 @@ var builtins = map[string]*env.Builtin{
 			}
 		},
 	},
-
 	"equals": {
 		Argsn: 2,
 		Fn: func(env1 *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
@@ -74,6 +73,18 @@ var builtins = map[string]*env.Builtin{
 				res = 1
 			} else {
 				res = 0
+			}
+			return env.Integer{res}
+		},
+	},
+	"not_equals": {
+		Argsn: 2,
+		Fn: func(env1 *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			var res int64
+			if arg0.GetKind() == arg1.GetKind() && arg0.Inspect(*env1.Idx) == arg1.Inspect(*env1.Idx) {
+				res = 0
+			} else {
+				res = 1
 			}
 			return env.Integer{res}
 		},

--- a/evaldo/builtins_test.go
+++ b/evaldo/builtins_test.go
@@ -2,9 +2,9 @@
 package evaldo
 
 import (
+	"fmt"
 	"rye/env"
 	"rye/loader"
-	"fmt"
 
 	//"fmt"
 	"testing"


### PR DESCRIPTION
Hey!

I wanted to explore how easy/hard it is to add a new operator to rye. In this case, I've added `not_equals` operator that is essentially implemented the same as `equals` with the reverted return.

It's not hard. ;)

Cheers!