### PR TITLE
Docker image improvements

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -6,15 +6,14 @@ WORKDIR /go/src/rye
 
 COPY . .
 
-RUN export GO111MODULE=auto && \
-	go get -d -v -insecure \
+ENV GO111MODULE=auto
+
+RUN go get -d -v -insecure \
 	github.com/refaktor/go-peg \
 	github.com/refaktor/liner \
 	golang.org/x/net/html \
 	github.com/pkg/profile \
-	github.com/pkg/term
-
-RUN export GO111MODULE=auto && \
+	github.com/pkg/term && \
 	mkdir -p /out && \
     go build -x -tags "b_tiny" -o /out/rye .
 


### PR DESCRIPTION
1. When dealing with Docker and its images it is better to define environment variables via [`ENV` instruction](https://docs.docker.com/engine/reference/builder/#env); this gives you the power to redefine the value when building images or running containers. 
2. Fewer steps than the image has; fewer layers are created; smaller the image. Yes; in this case, u have a two-step build so it doesn't matter that much but it's still a good practice.