### PR TITLE
[Improvements] Error handling in IO and Validation files

### DIFF
--- a/evaldo/builtins_validation.go
+++ b/evaldo/builtins_validation.go
@@ -46,6 +46,9 @@ func Validation_EvalBlock(es *env.ProgramState, vals env.Dict) (env.Dict, map[st
 					res[name] = val
 				}
 			}
+		default:
+			fmt.Println("Type is not matching - Validation_EvalBlock.")
+			//TODO-FIXME
 		}
 	}
 	//set the last value too
@@ -68,6 +71,9 @@ func Validation_EvalBlock_List(es *env.ProgramState, vals env.List) (env.Object,
 			if verr != nil {
 				notes = append(notes, verr)
 			}
+		default:
+			fmt.Println("Type is not matching - Validation_EvalBlock_List.")
+			//TODO-FIXME
 		}
 	}
 


### PR DESCRIPTION
**Changes:**
1. Changes in IO and Validation built-in files
2. Rename ProgramState env1 variable to ps
3. In the validation file added TODO-FIXME
4. In IO file many places - ioutil.ReadFile is used. Which needs to be removed in future as it is depreciated from Go 1.16
5. Added TODODOC in IO file
6.  **DOUBTS:**
  6.1 rye-file//copy and rye-file//copy  both are calling same function. What is the difference between these two?
  6.2 May be by mistake reverse function is used
        https-schema//post -> func __http_s_post
        http-schema//get -> func __https_s_get
        There is some mistake? these should be reverse?
