### PR TITLE
[Improvements] Error handling for telegram, bcrypt, bson and conversion

### DIFF
--- a/evaldo/builtins_bcrypt.go
+++ b/evaldo/builtins_bcrypt.go
@@ -11,22 +11,22 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-func __bcrypt_hash(env1 *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+func __bcrypt_hash(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
 	switch str := arg0.(type) {
 	case env.String:
 		bytes, err := bcrypt.GenerateFromPassword([]byte(str.Value), bcrypt.DefaultCost)
 		if err != nil {
-			env1.FailureFlag = true
-			return env.NewError("problem hashing")
+			ps.FailureFlag = true
+			return MakeBuiltinError(ps, "Problem in hashing.", "__bcrypt_hash")
 		}
 		return env.String{string(bytes)}
 	default:
-		env1.FailureFlag = true
-		return env.NewError("arg 1 should be string")
+		ps.FailureFlag = true
+		return MakeArgError(ps, 1, []env.Type{env.StringType}, "__bcrypt_hash")
 	}
 }
 
-func __bcrypt_check(env1 *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+func __bcrypt_check(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
 	switch password := arg1.(type) {
 	case env.String:
 		switch hash := arg0.(type) {
@@ -38,26 +38,26 @@ func __bcrypt_check(env1 *env.ProgramState, arg0 env.Object, arg1 env.Object, ar
 				return env.Integer{0}
 			}
 		default:
-			env1.FailureFlag = true
-			return env.NewError("arg 1 should be string")
+			ps.FailureFlag = true
+			return MakeArgError(ps, 1, []env.Type{env.StringType}, "__bcrypt_check")
 		}
 	default:
-		env1.FailureFlag = true
-		return env.NewError("arg 1 should be string")
+		ps.FailureFlag = true
+		return MakeArgError(ps, 2, []env.Type{env.StringType}, "__bcrypt_check")
 	}
 }
 
-func __generate_token(env1 *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+func __generate_token(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
 	switch n := arg0.(type) {
 	case env.Integer:
 		b := make([]byte, n.Value)
 		if _, err := rand.Read(b); err != nil {
-			return env.NewError("problem reading random stream")
+			return MakeBuiltinError(ps, "Problem reading random stream.", "__generate_token")
 		}
 		return env.String{hex.EncodeToString(b)}
 	default:
-		env1.FailureFlag = true
-		return env.NewError("arg 1 should be string")
+		ps.FailureFlag = true
+		return MakeArgError(ps, 1, []env.Type{env.IntegerType}, "__generate_token")
 	}
 }
 
@@ -65,21 +65,24 @@ var Builtins_bcrypt = map[string]*env.Builtin{
 
 	"bcrypt-hash": {
 		Argsn: 1,
-		Fn: func(env1 *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
-			return __bcrypt_hash(env1, arg0, arg1, arg2, arg3, arg4)
+		Doc:   "Generate hashing.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			return __bcrypt_hash(ps, arg0, arg1, arg2, arg3, arg4)
 		},
 	},
 
 	"bcrypt-check": {
 		Argsn: 2,
-		Fn: func(env1 *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
-			return __bcrypt_check(env1, arg0, arg1, arg2, arg3, arg4)
+		Doc:   "Compare hash and password.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			return __bcrypt_check(ps, arg0, arg1, arg2, arg3, arg4)
 		},
 	},
 	"generate-token": {
 		Argsn: 1,
-		Fn: func(env1 *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
-			return __generate_token(env1, arg0, arg1, arg2, arg3, arg4)
+		Doc:   "Generate token for hashing.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			return __generate_token(ps, arg0, arg1, arg2, arg3, arg4)
 		},
 	},
 }

--- a/evaldo/builtins_conversion.go
+++ b/evaldo/builtins_conversion.go
@@ -136,27 +136,26 @@ func conversion_evalWord(word env.Word, ps *env.ProgramState, vals env.Object) (
 	default:
 		return nil, nil
 	}
-	return nil, nil
 }
 
-func BuiConvert(env1 *env.ProgramState, arg0 env.Object, arg1 env.Object) env.Object {
+func BuiConvert(ps *env.ProgramState, arg0 env.Object, arg1 env.Object) env.Object {
 	switch blk := arg1.(type) {
 	case env.Block:
-		ser1 := env1.Ser
-		env1.Ser = blk.Series
+		ser1 := ps.Ser
+		ps.Ser = blk.Series
 		var vals env.Object
 		switch rmap := arg0.(type) {
 		case env.RyeCtx:
-			vals = Conversion_EvalBlockCtx(env1, rmap)
+			vals = Conversion_EvalBlockCtx(ps, rmap)
 		case env.Dict:
-			vals = Conversion_EvalBlockDict(env1, rmap)
+			vals = Conversion_EvalBlockDict(ps, rmap)
 		default:
-			return env.NewError("arg 1 should be Dict")
+			return MakeArgError(ps, 1, []env.Type{env.DictType, env.CtxType}, "BuiConvert")
 		}
-		env1.Ser = ser1
+		ps.Ser = ser1
 		return vals
 	default:
-		return env.NewError("arg 2 should be block")
+		return MakeArgError(ps, 2, []env.Type{env.BlockType}, "BuiConvert")
 	}
 }
 
@@ -164,15 +163,17 @@ var Builtins_conversion = map[string]*env.Builtin{
 
 	"convert": {
 		Argsn: 2,
-		Fn: func(env1 *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
-			return BuiConvert(env1, arg0, arg1)
+		Doc:   "TODODOC.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			return BuiConvert(ps, arg0, arg1)
 		},
 	},
 
 	"converter": {
 		Argsn: 3,
-		Fn: func(env1 *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
-			// obj := BuiValidate(env1, arg0, arg1)
+		Doc:   "TODODOC.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			// obj := BuiValidate(ps, arg0, arg1)
 			switch obj1 := arg0.(type) {
 			case env.Kind:
 				switch obj2 := arg1.(type) {
@@ -182,15 +183,14 @@ var Builtins_conversion = map[string]*env.Builtin{
 						obj2.SetConverter(obj1.Kind.Index, spec)
 						return obj2
 					default:
-						return env.NewError("3rd should be block")
+						return MakeArgError(ps, 3, []env.Type{env.BlockType}, "converter")
 					}
 				default:
-					return env.NewError("2nd should be block")
+					return MakeArgError(ps, 2, []env.Type{env.KindType, env.BlockType}, "converter")
 				}
 			default:
-				return env.NewError("1st should be block")
+				return MakeArgError(ps, 1, []env.Type{env.KindType}, "converter")
 			}
-			return env.NewError("error at the end")
 		},
 	},
 }

--- a/evaldo/builtins_telegrambot.go
+++ b/evaldo/builtins_telegrambot.go
@@ -59,23 +59,24 @@ var Builtins_telegrambot = map[string]*env.Builtin{
 
 	"new-telegram-bot": {
 		Argsn: 1,
-		Doc:   "",
+		Doc:   "Create new telegram bot using API value.",
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
 			switch arg := arg0.(type) {
 			case env.String:
 				bot, err := tgm.NewBotAPI(arg.Value)
 				if err != nil {
-					return makeError(ps, "Arg 1 should be Integer.")
+					return MakeBuiltinError(ps, "Error in NewBotAPI function.", "new-telegram-bot")
 				}
 				return *env.NewNative(ps.Idx, bot, "telegram-bot")
 			default:
-				return makeError(ps, "Arg 1 should be Integer.")
+				return MakeArgError(ps, 1, []env.Type{env.StringType}, "new-telegram-bot")
 			}
 		},
 	},
 
 	"telegram-bot//on-update": {
 		Argsn: 2,
+		Doc:   "Get telegram update and add to Rye dictionary",
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
 			switch bot := arg0.(type) {
 			case env.Native:
@@ -100,16 +101,17 @@ var Builtins_telegrambot = map[string]*env.Builtin{
 					ps.Ser = ser
 					return env.Integer{1}
 				default:
-					return makeError(ps, "Arg 1 should be Native.")
+					return MakeArgError(ps, 2, []env.Type{env.BlockType}, "telegram-bot//on-update")
 				}
 			default:
-				return makeError(ps, "Arg 2 should be Block.")
+				return MakeArgError(ps, 1, []env.Type{env.NativeType}, "telegram-bot//on-update")
 			}
 		},
 	},
 
 	"telegram-message//send": {
 		Argsn: 2,
+		Doc:   "Send message in telegram bot.",
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
 			switch msg := arg0.(type) {
 			case env.Native:
@@ -118,16 +120,17 @@ var Builtins_telegrambot = map[string]*env.Builtin{
 					bot.Value.(*tgm.BotAPI).Send(msg.Value.(tgm.MessageConfig))
 					return arg0
 				default:
-					return makeError(ps, "Arg 1 should be Native.")
+					return MakeArgError(ps, 2, []env.Type{env.NativeType}, "telegram-message//send")
 				}
 			default:
-				return makeError(ps, "Arg 1 should be Native.")
+				return MakeArgError(ps, 1, []env.Type{env.NativeType}, "telegram-message//send")
 			}
 
 		},
 	},
 	"new-telegram-message": {
 		Argsn: 2,
+		Doc:   "Create new telegram bot message.",
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
 			switch cid := arg0.(type) {
 			case env.Integer:
@@ -136,10 +139,10 @@ var Builtins_telegrambot = map[string]*env.Builtin{
 					msg := tgm.NewMessage(cid.Value, txt.Value)
 					return *env.NewNative(ps.Idx, msg, "telegram-message")
 				default:
-					return makeError(ps, "Arg 2 should String.")
+					return MakeArgError(ps, 2, []env.Type{env.StringType}, "new-telegram-message")
 				}
 			default:
-				return makeError(ps, "Arg 1 should be Integer.")
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType}, "new-telegram-message")
 			}
 		},
 	},


### PR DESCRIPTION
**Changes:**
1. Error handling for telegram, bcrypt, bson and conversion files completed
2. Rename ProgramState variable to ps
3. Removed unused return
4. Added Doc string and TODODOC
5.  For builtins_cayley.go build is not working (No change from my side. It is older code)
**go build -tags "b_cayley"**
evaldo/builtins_cayley.go:12:2: no required module provides package github.com/cayleygraph/cayley/query/path; to add it:
        go get github.com/cayleygraph/cayley/query/path