### PR TITLE
Add new builtins

### DIFF
--- a/env/idxs.go
+++ b/env/idxs.go
@@ -45,6 +45,7 @@ var NativeTypes = [...]string{ // Todo change to BuiltinTypes
 	"Kindword",
 	"Converter",
 	"Time",
+	"SpreadsheetRowType",
 	"Decimal",
 	"Vector",
 }

--- a/evaldo/builtins.go
+++ b/evaldo/builtins.go
@@ -348,7 +348,7 @@ var builtins = map[string]*env.Builtin{
 
 	"is-string": { // **
 		Argsn: 1,
-		Doc:   "Returns true if value is string.",
+		Doc:   "Returns true if value is a string.",
 		Pure:  true,
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
 			if arg0.Type() == env.StringType {
@@ -361,7 +361,7 @@ var builtins = map[string]*env.Builtin{
 
 	"is-integer": { // **
 		Argsn: 1,
-		Doc:   "Returns true if value is string.",
+		Doc:   "Returns true if value is an integer.",
 		Pure:  true,
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
 			if arg0.Type() == env.IntegerType {
@@ -372,7 +372,31 @@ var builtins = map[string]*env.Builtin{
 		},
 	},
 
-	// TODO-ADD: is-decimal , is-number (integer or decimal)
+	"is-decimal": { // **
+		Argsn: 1,
+		Doc:   "Returns true if value is a decimal.",
+		Pure:  true,
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			if arg0.Type() == env.DecimalType {
+				return env.Integer{1}
+			} else {
+				return env.Integer{0}
+			}
+		},
+	},
+
+	"is-number": { // **
+		Argsn: 1,
+		Doc:   "Returns true if value is a number (integer or decimal).",
+		Pure:  true,
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			if arg0.Type() == env.IntegerType || arg0.Type() == env.DecimalType {
+				return env.Integer{1}
+			} else {
+				return env.Integer{0}
+			}
+		},
+	},
 
 	"to-uri": { // * TODO-FIXME: return possible failures
 		Argsn: 1,
@@ -417,7 +441,7 @@ var builtins = map[string]*env.Builtin{
 		},
 	},
 
-	"is-positive": { // ** , TODO-FIX: handle Decimal
+	"is-positive": { // **
 		Argsn: 1,
 		Doc:   "Returns true if integer is positive.",
 		Pure:  true,
@@ -429,13 +453,41 @@ var builtins = map[string]*env.Builtin{
 				} else {
 					return env.Integer{0}
 				}
+			case env.Decimal:
+				if arg.Value > 0 {
+					return env.Integer{1}
+				} else {
+					return env.Integer{0}
+				}
 			default:
-				return MakeArgError(ps, 1, []env.Type{env.IntegerType}, "inc")
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.DecimalType}, "is-positive")
 			}
 		},
 	},
 
-	// TODO-ADD: is-zero
+	"is-zero": { // **
+		Argsn: 1,
+		Doc:   "Returns true if integer is zero.",
+		Pure:  true,
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) (res env.Object) {
+			switch arg := arg0.(type) {
+			case env.Integer:
+				if arg.Value == 0 {
+					return env.Integer{1}
+				} else {
+					return env.Integer{0}
+				}
+			case env.Decimal:
+				if arg.Value == 0 {
+					return env.Integer{1}
+				} else {
+					return env.Integer{0}
+				}
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.DecimalType}, "is-zero")
+			}
+		},
+	},
 
 	"inc!": { // **
 		Argsn: 1,

--- a/tests/builtins.html
+++ b/tests/builtins.html
@@ -55,6 +55,16 @@
 <pre class='prettyprint lang-rye'><code language='lang-rye'>0 .is-positive
 ; returns 0</code></pre>
 </div>
+<h3>is-zero</h3><p>Pure Builtin(1): Returns true if integer is zero.</p><div class='group'>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>is-zero 0
+; returns 1</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>0 .is-zero
+; returns 1</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>is-zero 0.000000
+; returns 1</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>is-zero 0.100000
+; returns 0</code></pre>
+</div>
 <h3>factor-of</h3><p>Pure Builtin(2): Checks if a first argument is a factor of second.</p><div class='group'>
 <pre class='prettyprint lang-rye'><code language='lang-rye'>factor-of 10 2
 ; returns 1</code></pre>
@@ -220,13 +230,29 @@
 <pre class='prettyprint lang-rye'><code language='lang-rye'>to-file "file.txt"
 ; returns file://file.txt</code></pre>
 </div>
-<h3>is-integer</h3><p>Pure Builtin(1): Returns true if value is string.</p><div class='group'>
+<h3>is-integer</h3><p>Pure Builtin(1): Returns true if value is an integer.</p><div class='group'>
 <pre class='prettyprint lang-rye'><code language='lang-rye'>is-integer 123
 ; returns 1</code></pre>
 <pre class='prettyprint lang-rye'><code language='lang-rye'>is-integer "ABC"
 ; returns 0</code></pre>
 </div>
-<h3>is-string</h3><p>Pure Builtin(1): Returns true if value is string.</p><div class='group'>
+<h3>is-decimal</h3><p>Pure Builtin(1): Returns true if value is a decimal.</p><div class='group'>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>is-decimal 123.456000
+; returns 1</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>is-decimal 123
+; returns 0</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>is-decimal "ABC"
+; returns 0</code></pre>
+</div>
+<h3>is-number</h3><p>Pure Builtin(1): Returns true if value is a number (integer or decimal).</p><div class='group'>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>is-number 123
+; returns 1</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>is-number 123.456000
+; returns 1</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>is-number "ABC"
+; returns 0</code></pre>
+</div>
+<h3>is-string</h3><p>Pure Builtin(1): Returns true if value is a string.</p><div class='group'>
 <pre class='prettyprint lang-rye'><code language='lang-rye'>is-string "ABC"
 ; returns 1</code></pre>
 <pre class='prettyprint lang-rye'><code language='lang-rye'>is-string 123

--- a/tests/builtins.rye
+++ b/tests/builtins.rye
@@ -77,6 +77,16 @@ section "Working with numbers"
 		; TODO -- same for decimal
 	}
 
+	group "is-zero"
+	mold\nowrap ?is-zero
+	{ { integer decimal } }
+	{
+		equal { is-zero 0 } 1
+		equal { 0 .is-zero } 1
+		equal { is-zero 0.0 } 1
+		equal { is-zero 0.1 } 0
+	}
+
 	group "factor-of"
 	mold\nowrap ?factor-of
 	{ { integer } { integer } }
@@ -381,11 +391,29 @@ section "Type conversion and checking"
 	}
 
 	group "is-integer"
-	mold\nowrap ?is-string
+	mold\nowrap ?is-integer
 	{ { object } }
 	{
 		equal { is-integer 123 } 1
 		equal { is-integer "ABC" } 0
+	}
+
+	group "is-decimal"
+	mold\nowrap ?is-decimal
+	{ { object } }
+	{
+		equal { is-decimal 123.456 } 1
+		equal { is-decimal 123 } 0
+		equal { is-decimal "ABC" } 0
+	}
+
+	group "is-number"
+	mold\nowrap ?is-number
+	{ { object } }
+	{
+		equal { is-number 123 } 1
+		equal { is-number 123.456 } 1
+		equal { is-number "ABC" } 0
 	}
 
 	group "is-string"


### PR DESCRIPTION
This PR adds `is-decimal`, `is-number` and `is-zero`. It also fixes a few bugs.

The line added in `env/idxs.go` is to sync up with `env.Type` so that error reporting on invalid types works correctly. Not sure if this breaks anything, please double check.

Also, I'm getting loaders issues when trying to do anything with negative numbers, eg.:
```
×> is-integer -1
Loader error at line: 1
{ is-integer -1 }
--------------^
×> -1 .is-integer
Loader error at line: 1
{ -1 .is-integer }
---^
```
Is this expected?