### PR TITLE
Basic golangci-lint workflow configuration

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,58 @@
+name: golangci-lint
+on:
+    push:
+        branches: [ "main" ]
+    pull_request:
+        branches: [ "main" ]
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: false
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Require: The version of golangci-lint to use.
+          # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
+          # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
+          version: v1.54
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          #
+          # Note: By default, the `.golangci.yml` file should be at the root of the repository.
+          # The location of the configuration file can be changed by using `--config=`
+          # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0 
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true, then all caching functionality will be completely disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true, then the action won't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true, then the action won't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true
+
+          # Optional: The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
+          # install-mode: "goinstall"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,164 @@
+linters-settings:
+  depguard:
+    # new configuration
+    rules:
+      logger:
+        deny:
+          # logging is allowed only by logutils.Log,
+          # logrus is allowed to use only in logutils package.
+          - pkg: "github.com/sirupsen/logrus"
+            desc: logging is allowed only by logutils.Log
+  dupl:
+    threshold: 100
+  funlen:
+    lines: -1 # the number of lines (code + empty lines) is not a right metric and leads to code without empty line or one-liner.
+    statements: 50
+  goconst:
+    min-len: 2
+    min-occurrences: 3
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - whyNoLint
+  gocyclo:
+    min-complexity: 15
+  gofmt:
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
+  goimports:
+    local-prefixes: github.com/golangci/golangci-lint
+  gomnd:
+    # don't include the "operation" and "assign"
+    checks:
+      - argument
+      - case
+      - condition
+      - return
+    ignored-numbers:
+      - '0'
+      - '1'
+      - '2'
+      - '3'
+    ignored-functions:
+      - strings.SplitN
+
+  govet:
+    check-shadowing: true
+    settings:
+      # printf:
+      #   funcs:
+      #     - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+      #     - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+      #     - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+      #     - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+  lll:
+    line-length: 140
+  misspell:
+    locale: US
+  nolintlint:
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+  revive:
+    rules:
+      - name: unexported-return
+        disabled: true
+      - name: unused-parameter
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - depguard
+    - dogsled
+    # - dupl
+    # - errcheck
+    - exportloopref
+    # - funlen
+    - gocheckcompilerdirectives
+    - gochecknoinits
+    # - goconst
+    # - gocritic
+    # - gocyclo
+    # - gofmt
+    # - goimports
+    # - gomnd
+    - goprintffuncname
+    - gosec
+    # - gosimple
+    - govet
+    # - ineffassign
+    # - lll
+    # - misspell
+    # - nakedret
+    - noctx
+    - nolintlint
+    # - revive
+    # - staticcheck
+    # - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    # - unused
+    # - whitespace
+
+  # don't enable:
+  # - asciicheck
+  # - scopelint
+  # - gochecknoglobals
+  # - gocognit
+  # - godot
+  # - godox
+  # - goerr113
+  # - interfacer
+  # - maligned
+  # - nestif
+  # - prealloc
+  # - testpackage
+  # - wsl
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - text: "evaldo"
+      linters: typecheck
+
+    # - path: _test\.go
+    #   linters:
+    #     - gomnd
+
+    # - path: pkg/golinters/errcheck.go
+    #   text: "SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead"
+    # - path: pkg/commands/run.go
+    #   text: "SA1019: lsc.Errcheck.Exclude is deprecated: use ExcludeFunctions instead"
+    # - path: pkg/commands/run.go
+    #   text: "SA1019: e.cfg.Run.Deadline is deprecated: Deadline exists for historical compatibility and should not be used."
+
+    # - path: pkg/golinters/gofumpt.go
+    #   text: "SA1019: settings.LangVersion is deprecated: use the global `run.go` instead."
+    # - path: pkg/golinters/staticcheck_common.go
+    #   text: "SA1019: settings.GoVersion is deprecated: use the global `run.go` instead."
+    # - path: pkg/lint/lintersdb/manager.go
+    #   text: "SA1019: (.+).(GoVersion|LangVersion) is deprecated: use the global `run.go` instead."
+    # - path: pkg/golinters/unused.go
+    #   text: "rangeValCopy: each iteration copies 160 bytes \\(consider pointers or indexing\\)"
+    # - path: test/(fix|linters)_test.go
+    #   text: "string `gocritic.go` has 3 occurrences, make it a constant"
+
+run:
+  timeout: 5m
+  # skip-dirs:
+  #   - test/testdata_etc # test files
+  #   - internal/cache # extracted from Go code
+  #   - internal/renameio # extracted from Go code
+  #   - internal/robustio # extracted from Go code
+  


### PR DESCRIPTION
Make use of https://golangci-lint.run/ in the CI pipeline.

Config based on https://github.com/golangci/golangci-lint/blob/master/.golangci.yml +disabled failing linters

More linters should be enabled gradually as their problems are fixed

Tested in my fork with:
* success, same as this PR: https://github.com/stefanb/rye/pull/2
* breaking by enabling a new linter: https://github.com/stefanb/rye/pull/3
* breaking by introducing a new codesmell:  https://github.com/stefanb/rye/pull/4 rsulting in automagic code review annotation:
<img width="449" alt="image" src="https://github.com/refaktor/rye/assets/319826/815d2cf7-42bd-4161-812d-1fcd1a53b41c">


Further configuration is possible as per 
* https://github.com/golangci/golangci-lint-action
* https://golangci-lint.run/usage/configuration/