### PR TITLE
Enable mispell linter + fix warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,7 +63,7 @@ linters-settings:
   lll:
     line-length: 140
   misspell:
-    locale: US
+    # locale: US # or UK, uncomment if want to be picky about colour/color behaviour/behavior
   nolintlint:
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
@@ -98,7 +98,7 @@ linters:
     - govet
     # - ineffassign
     # - lll
-    # - misspell
+    - misspell
     # - nakedret
     - noctx
     - nolintlint

--- a/env/object.go
+++ b/env/object.go
@@ -223,7 +223,7 @@ type Uri struct {
 }
 
 func NewUri1(index *Idxs, path string) *Uri {
-	scheme := strings.Split(path, "://")[0] // + "-schema" // TODO -- this is just temporary .. so we test it further, make propper once at that level
+	scheme := strings.Split(path, "://")[0] // + "-schema" // TODO -- this is just temporary .. so we test it further, make proper once at that level
 	idxSch := index.IndexWord(scheme)
 	kind := scheme + "-schema"
 	idxKind := index.IndexWord(kind)
@@ -232,7 +232,7 @@ func NewUri1(index *Idxs, path string) *Uri {
 }
 
 func NewUri(index *Idxs, scheme Word, path string) *Uri {
-	kindstr := strings.Split(path, "://")[0] + "-schema" // TODO -- this is just temporary .. so we test it further, make propper once at that level
+	kindstr := strings.Split(path, "://")[0] + "-schema" // TODO -- this is just temporary .. so we test it further, make proper once at that level
 	idx := index.IndexWord(kindstr)
 	nat := Uri{scheme, path, Word{idx}}
 	return &nat


### PR DESCRIPTION
Not picky about US or UK variant, as both are currently present in the code.