### PR TITLE
Add list and builtin block support for partition

### DIFF
--- a/env/object.go
+++ b/env/object.go
@@ -1375,6 +1375,8 @@ func NewListFromSeries(block TSeries) List {
 			data[i] = k.Value
 		case Decimal:
 			data[i] = k.Value
+		case List:
+			data[i] = k
 		}
 	}
 	return List{data, Word{0}}

--- a/tests/builtins.html
+++ b/tests/builtins.html
@@ -726,12 +726,26 @@
 ; returns "123"</code></pre>
 </div>
 <h3>partition</h3><p>Pure Builtin(2): Partitions a series by evaluating a block of code.</p><div class='group'>
-<pre class='prettyprint lang-rye'><code language='lang-rye'>{ 1 2 3 4 } .partition { > 2 }
+<pre class='prettyprint lang-rye'><code language='lang-rye'>partition { 1 2 3 4 } { > 2 }
 ; returns { { 1 2 } { 3 4 } }</code></pre>
-<pre class='prettyprint lang-rye'><code language='lang-rye'>{ "a" "b" 1 "c" "d" } .partition { .is-integer }
+<pre class='prettyprint lang-rye'><code language='lang-rye'>partition { "a" "b" 1 "c" "d" } { .is-integer }
 ; returns { { "a" "b" } { 1 } { "c" "d" } }</code></pre>
-<pre class='prettyprint lang-rye'><code language='lang-rye'>"aaabbccc" .partition { , }
+<pre class='prettyprint lang-rye'><code language='lang-rye'>partition { "a" "b" 1 "c" "d" } is-integer
+; returns { { "a" "b" } { 1 } { "c" "d" } }</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>partition { } { > 2 }
+; returns { { } }</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>partition list { 1 2 3 4 } { > 2 }
+; returns L[ L[ 1  2 ]  L[ 3  4 ] ]</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>partition list { "a" "b" 1 "c" "d" } is-integer
+; returns L[ L[ a  b ]  L[ 1 ]  L[ c  d ] ]</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>partition list { } { > 2 }
+; returns L[ L[] ]</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>partition "aaabbccc" { , }
 ; returns L[ aaa  bb  ccc ]</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>partition "" { , }
+; returns L[  ]</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>partition "aaabbccc" is-string
+; returns L[ aaabbccc ]</code></pre>
 </div>
 <h3>group</h3><p>Function(4)</p><div class='group'>
 <pre class='prettyprint lang-rye'><code language='lang-rye'>{ "Anne" "Mitch" "Anya" } .group { .first }
@@ -746,6 +760,11 @@
 ; ]</code></pre>
 <pre class='prettyprint lang-rye'><code language='lang-rye'>{ } .group { .first }
 ; returns [
+; ]</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>{ "Anne" "Mitch" "Anya" } .list .group { .first }
+; returns [
+;  A: L[ Anne  Anya ]
+;  M: L[ Mitch ]
 ; ]</code></pre>
 <pre class='prettyprint lang-rye'><code language='lang-rye'>{ "Anne" "Mitch" "Anya" } .list .group first
 ; returns [

--- a/tests/builtins.rye
+++ b/tests/builtins.rye
@@ -951,12 +951,16 @@ section "Higher order like functions"
 	mold\nowrap ?partition
 	{ { block } { block } }
 	{
-		equal { { 1 2 3 4 } .partition { > 2 } } { { 1 2 } { 3 4 } }
-		; equal { list { 1 2 3 4 } .partition { > 2 } } list { list { 1 2 } list { 3 4 } }
-		equal { { "a" "b" 1 "c" "d" } .partition { .is-integer } } { { "a" "b" } { 1 } { "c" "d" } }
-		equal { "aaabbccc" .partition { , } } list { "aaa" "bb" "ccc" }
-		; equal { { } .partition { > 2 } } { }
-		; equal { list { } .partition { > 2 } } list { }
+		equal { partition { 1 2 3 4 } { > 2 } } { { 1 2 } { 3 4 } }
+		equal { partition { "a" "b" 1 "c" "d" } { .is-integer } } { { "a" "b" } { 1 } { "c" "d" } }
+		equal { partition { "a" "b" 1 "c" "d" } ?is-integer } { { "a" "b" } { 1 } { "c" "d" } }
+		equal { partition { } { > 2 } } { { } }
+		equal { partition list { 1 2 3 4 } { > 2 } } list vals { list { 1 2 } list { 3 4 } }
+		equal { partition list { "a" "b" 1 "c" "d" } ?is-integer } list vals { list { "a" "b" } list { 1 } list { "c" "d" } }
+		equal { partition list { } { > 2 } } list vals { list { } }
+		equal { partition "aaabbccc" { , } } list { "aaa" "bb" "ccc" }
+		equal { partition "" { , } } list { "" }
+		equal { partition "aaabbccc" ?is-string } list { "aaabbccc" }
 	}	
 	group "group"
 	mold\nowrap ?group
@@ -970,7 +974,6 @@ section "Higher order like functions"
 		equal { { "Anne" "Mitch" "Anya" } .list .group ?first } dict vals { "A" list { "Anne" "Anya" } "M" list { "Mitch" } }
 		equal { { } .list .group { .first } } dict vals { }
 		equal { try { { 1 2 3 4 } .group { .even } } |type? } 'error ; TODO keys can only be string currently
-		
 	}	
 	group "produce"
 	mold\nowrap ?produce


### PR DESCRIPTION
This PR finishes adding list and string support for higher order functions (https://github.com/refaktor/rye/pull/45).

Also it handles nesting a list into a list.