### PR TITLE
Enable most feature tags for CI builds, cleanup

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -6,8 +6,7 @@ WORKDIR /go/src/rye
 
 COPY . .
 
-RUN bash go-get-tiny.bash \
-    mkdir -p /out && \
+RUN mkdir -p /out && \
     go build -x -tags "b_tiny" -o /out/rye .
 
 FROM alpine AS bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,13 @@ jobs:
         go-version: '1.21'
 
     - name: Build
-      run: go build -tags "b_tiny,b_sqlite,b_http,b_sql,b_postgres,b_bson,b_crypto,b_smtpd,b_mail,b_bctypt,b_telegram,b_norepl" -o bin/rye
+      # Enable all features for CI builds. 
+      # TODO: add currently problematic tags: b_cayley,b_gtk,b_nng,b_qframe,b_raylib
+      run: go build -v -tags "b_sqlite,b_http,b_sql,b_postgres,b_bson,b_crypto,b_smtpd,b_mail,b_bcrypt,b_telegram,b_html,b_contrib,b_ebitengine,b_openai,b_email,b_mail,b_mysql,b_nats,b_psql,b_psutil,b_sxml,b_echo,b_webview" -o bin/rye
 
     - name: Run Rye Tests
       run: cd tests ; ../bin/rye main.rye test
       timeout-minutes: 1
 
 #    - name: Test
-#      run: go test -v -tags "b_tiny,b_sqlite,b_http,b_sql,b_postgres,b_openai,b_bson,b_crypto,b_smtpd,b_mail,b_postmark,b_bctypt,b_telegram" ./...
+#      run: go test -v -tags "b_tiny,b_sqlite,b_http,b_sql,b_postgres,b_openai,b_bson,b_crypto,b_smtpd,b_mail,b_postmark,b_bcrypt,b_telegram" ./...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
 
     - name: Build
       # Enable all features for CI builds. 
-      # TODO: add currently problematic tags: b_cayley,b_gtk,b_nng,b_qframe,b_raylib,b_webview
-      run: go build -v -tags "b_sqlite,b_http,b_sql,b_postgres,b_bson,b_crypto,b_smtpd,b_mail,b_bcrypt,b_telegram,b_html,b_contrib,b_ebitengine,b_openai,b_email,b_mail,b_mysql,b_nats,b_psql,b_psutil,b_sxml,b_echo" -o bin/rye
+      # TODO: add currently problematic tags: b_cayley,b_gtk,b_nng,b_qframe,b_raylib,b_webview,b_ebitengine
+      run: go build -v -tags "b_sqlite,b_http,b_sql,b_postgres,b_bson,b_crypto,b_smtpd,b_mail,b_bcrypt,b_telegram,b_html,b_contrib,b_openai,b_email,b_mail,b_mysql,b_nats,b_psql,b_psutil,b_sxml,b_echo" -o bin/rye
 
     - name: Run Rye Tests
       run: cd tests ; ../bin/rye main.rye test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
 
     - name: Build
       # Enable all features for CI builds. 
-      # TODO: add currently problematic tags: b_cayley,b_gtk,b_nng,b_qframe,b_raylib
-      run: go build -v -tags "b_sqlite,b_http,b_sql,b_postgres,b_bson,b_crypto,b_smtpd,b_mail,b_bcrypt,b_telegram,b_html,b_contrib,b_ebitengine,b_openai,b_email,b_mail,b_mysql,b_nats,b_psql,b_psutil,b_sxml,b_echo,b_webview" -o bin/rye
+      # TODO: add currently problematic tags: b_cayley,b_gtk,b_nng,b_qframe,b_raylib,b_webview
+      run: go build -v -tags "b_sqlite,b_http,b_sql,b_postgres,b_bson,b_crypto,b_smtpd,b_mail,b_bcrypt,b_telegram,b_html,b_contrib,b_ebitengine,b_openai,b_email,b_mail,b_mysql,b_nats,b_psql,b_psutil,b_sxml,b_echo" -o bin/rye
 
     - name: Run Rye Tests
       run: cd tests ; ../bin/rye main.rye test

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Install build-esential if you don't already have it, for packages that require c
 Rye has many bindings, that you can determine at build time, so (currently) you get a specific Rye binary for your specific project. This is an example of a build with many bindings. 
 I've been working on a way to make this more elegant and systematic, but the manual version is:
 
-    go build -tags "b_tiny,b_sqlite,b_http,b_sql,b_postgres,b_openai,b_bson,b_crypto,b_smtpd,b_mail,b_postmark,b_bctypt,b_telegram"
+    go build -tags "b_tiny,b_sqlite,b_http,b_sql,b_postgres,b_openai,b_bson,b_crypto,b_smtpd,b_mail,b_postmark,b_bcrypt,b_telegram"
 	
 # Build WASM version of Rye
 

--- a/README.md
+++ b/README.md
@@ -320,10 +320,6 @@ Clone the main branch from the Rye repository. There is a submodule (a different
 
     git clone --recurse-submodules https://github.com/refaktor/rye.git && cd rye
 
-Go get the dependencies for tiny build
-
-    bash go-get-tiny.bash
-    
 Build the tiny version of Rye
 
     go build -tags "b_tiny"

--- a/distribution-idea.md
+++ b/distribution-idea.md
@@ -26,7 +26,7 @@ You can then use tinyrye for general use around the shell. Tinyrye should have s
 
 When inside a project folder, you create rye.mod file where you list modules you want local rye to have.
 
-Then you use `rye-assist build` to build a local rye with those modules. It should also do go-get commands later, in first version you need to make them.
+Then you use `rye-assist build` to build a local rye with those modules.
 
 When adding modules you add them to rye.mod and rebuild.
 

--- a/go-get-more.bash
+++ b/go-get-more.bash
@@ -1,8 +1,0 @@
-go get github.com/go-telegram-bot-api/telegram-bot-api
-go get github.com/gobwas/ws
-go get github.com/gobwas/ws/wsutil
-go get github.com/gorilla/sessions
-go get github.com/mattn/go-sqlite3
-go get github.com/mhale/smtpd
-go get github.com/thomasberger/parsemail
-go get go.mongodb.org/mongo-driver/bson

--- a/go-get-tiny.bash
+++ b/go-get-tiny.bash
@@ -1,7 +1,0 @@
-go get github.com/refaktor/go-peg  # PEG parser (rye loader)
-go get github.com/refaktor/liner@v1.2.6   # library for REPL
-go get golang.org/x/net/html       # for html parsin - will probably remove for b_tiny
-go get github.com/pkg/profile      # for runtime profiling - will probably remove for b_tiny
-go get github.com/pkg/term         # 
-go get github.com/drewlanenga/govector # for vector datatype
-go get github.com/jinzhu/copier


### PR DESCRIPTION
- Enabled most feature tags for CI builds:
  - some flags would require installing additional C development libraries in github workflow (to be installed via apt prior to Go build)
  - some flags trigger Go build problems (to be investigated & fixed)
- Fixed typo b_bctypt -> b_bcrypt
- Cleanup bad Go module practice via `go-get-*.bash` files & all references as the dependancies were put into proper `go.mod` & `go.sum` files in prematurely merged #52