### PR TITLE
Enable wasm build in CI, dummy term package non-implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,5 +32,9 @@ jobs:
       run: cd tests ; ../bin/rye main.rye test
       timeout-minutes: 1
 
+    - name: Build WASM
+      run: |
+        GOOS=js GOARCH=wasm go build -v -tags "b_tiny,b_norepl" -o wasm/rye.wasm main_wasm.go
+
 #    - name: Test
 #      run: go test -v -tags "b_tiny,b_sqlite,b_http,b_sql,b_postgres,b_openai,b_bson,b_crypto,b_smtpd,b_mail,b_postmark,b_bcrypt,b_telegram" ./...

--- a/term/term.go
+++ b/term/term.go
@@ -1,3 +1,6 @@
+//go:build !wasm
+// +build !wasm
+
 package term
 
 import (

--- a/term/term_wasm.go
+++ b/term/term_wasm.go
@@ -1,0 +1,33 @@
+//go:build wasm
+// +build wasm
+
+package term
+
+import (
+	"rye/env"
+)
+
+// DisplayBlock is dummy non-implementation for wasm for display builtin
+func DisplayBlock(bloc env.Block, idx *env.Idxs) (env.Object, bool) {
+	panic("unimplemented")
+}
+
+// DisplayDict is dummy non-implementation for wasm for display builtin
+func DisplayDict(bloc env.Dict, idx *env.Idxs) (env.Object, bool) {
+	panic("unimplemented")
+}
+
+// DisplaySpreadsheetRow is dummy non-implementation for wasm for display builtin
+func DisplaySpreadsheetRow(bloc env.SpreadsheetRow, idx *env.Idxs) (env.Object, bool) {
+	panic("unimplemented")
+}
+
+// DisplayTable is dummy non-implementation for wasm for display builtin
+func DisplayTable(bloc env.Spreadsheet, idx *env.Idxs) (env.Object, bool) {
+	panic("unimplemented")
+}
+
+// SaveCurPos is dummy non-implementation for wasm for display builtin
+func SaveCurPos() {
+	panic("unimplemented")
+}


### PR DESCRIPTION
The dummy `term` package is needed for "display" builtin.