### PR TITLE
Use goreleaser for binary releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,5 +32,9 @@ jobs:
       run: cd tests ; ../bin/rye main.rye test
       timeout-minutes: 1
 
+    - name: Build WASM
+      run: |
+        GOOS=js GOARCH=wasm go build -v -tags "b_tiny,b_norepl" -o wasm/rye.wasm main_wasm.go
+
 #    - name: Test
 #      run: go test -v -tags "b_tiny,b_sqlite,b_http,b_sql,b_postgres,b_openai,b_bson,b_crypto,b_smtpd,b_mail,b_postmark,b_bcrypt,b_telegram" ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+# .github/workflows/release.yml
+name: goreleaser
+
+on:
+    push:
+        tags:
+          - 'v*.*.*'
+
+permissions:
+  contents: write
+  # packages: write
+  # issues: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # needs full git history for changelog generation
+          submodules: true
+
+      - run: git fetch --force --tags
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: stable
+
+      - uses: goreleaser/goreleaser-action@v5
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro':
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ data.txt
 *.bleve
 *.big.csv
 *.tar.gz
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,59 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines bellow are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    # - go mod tidy
+    # you may remove this if you don't need go generate
+    # - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      # - windows
+      - darwin
+      - js
+    goarch:
+      - amd64
+      - arm
+      - arm64
+      - wasm
+    
+    ignore: # List of combinations of GOOS + GOARCH + GOARM to ignore.
+      # - goos: windows
+      #   goarch: arm64
+      # - goos: windows
+      #   goarch: arm
+
+    flags:
+    - -tags=b_tiny,b_norepl
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/term/term.go
+++ b/term/term.go
@@ -1,3 +1,6 @@
+//go:build !wasm
+// +build !wasm
+
 package term
 
 import (

--- a/term/term_wasm.go
+++ b/term/term_wasm.go
@@ -1,0 +1,33 @@
+//go:build wasm
+// +build wasm
+
+package term
+
+import (
+	"rye/env"
+)
+
+// DisplayBlock is dummy non-implementation for wasm for display builtin
+func DisplayBlock(bloc env.Block, idx *env.Idxs) (env.Object, bool) {
+	panic("unimplemented")
+}
+
+// DisplayDict is dummy non-implementation for wasm for display builtin
+func DisplayDict(bloc env.Dict, idx *env.Idxs) (env.Object, bool) {
+	panic("unimplemented")
+}
+
+// DisplaySpreadsheetRow is dummy non-implementation for wasm for display builtin
+func DisplaySpreadsheetRow(bloc env.SpreadsheetRow, idx *env.Idxs) (env.Object, bool) {
+	panic("unimplemented")
+}
+
+// DisplayTable is dummy non-implementation for wasm for display builtin
+func DisplayTable(bloc env.Spreadsheet, idx *env.Idxs) (env.Object, bool) {
+	panic("unimplemented")
+}
+
+// SaveCurPos is dummy non-implementation for wasm for display builtin
+func SaveCurPos() {
+	panic("unimplemented")
+}


### PR DESCRIPTION
Test it localy via
````
goreleaser release --snapshot --clean
````

See
- https://goreleaser.com/
- https://github.com/goreleaser/goreleaser

Note: it is based on #56 to enable also WASM release, so merge that one first.

Log & artefacts:
````
$ goreleaser release --snapshot --clean
  • starting release...
  • loading                                          path=.goreleaser.yaml
  • skipping announce, publish and validate...
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=37d5b38e9e68446de8c6a2b714dd63cbbb10ec60 branch=goreleaser current_tag=v0.0.2 previous_tag=v0.0.1 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=0.0.2-SNAPSHOT-37d5b38
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/rye_js_wasm/rye.wasm
    • building                                       binary=dist/rye_linux_arm_6/rye
    • building                                       binary=dist/rye_darwin_arm64/rye
    • building                                       binary=dist/rye_linux_amd64_v1/rye
    • building                                       binary=dist/rye_linux_arm64/rye
    • building                                       binary=dist/rye_darwin_amd64_v1/rye
    • took: 1s
  • archives
    • creating                                       archive=dist/rye_Linux_x86_64.tar.gz
    • creating                                       archive=dist/rye_Darwin_arm64.tar.gz
    • creating                                       archive=dist/rye_Linux_armv6.tar.gz
    • creating                                       archive=dist/rye_Js_wasm.tar.gz
    • creating                                       archive=dist/rye_Darwin_x86_64.tar.gz
    • creating                                       archive=dist/rye_Linux_arm64.tar.gz
    • took: 2s
  • calculating checksums
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 3s
  • thanks for using goreleaser!

$ ls -go dist  
   rwxr-xr-x   3     96 B     Mon Dec 11 21:36:13 2023    rye_darwin_amd64_v1/
   rwxr-xr-x   3     96 B     Mon Dec 11 21:36:13 2023    rye_darwin_arm64/
   rwxr-xr-x   3     96 B     Mon Dec 11 21:36:13 2023    rye_js_wasm/
   rwxr-xr-x   3     96 B     Mon Dec 11 21:36:13 2023    rye_linux_amd64_v1/
   rwxr-xr-x   3     96 B     Mon Dec 11 21:36:13 2023    rye_linux_arm64/
   rwxr-xr-x   3     96 B     Mon Dec 11 21:36:13 2023    rye_linux_arm_6/
   rw-r--r--   1      3 KiB   Mon Dec 11 21:36:14 2023    artifacts.json 
   rw-r--r--   1      3 KiB   Mon Dec 11 21:36:12 2023    config.yaml 
   rw-r--r--   1    235 B     Mon Dec 11 21:36:14 2023    metadata.json 
   rw-r--r--   1    534 B     Mon Dec 11 21:36:14 2023    rye_0.0.2-SNAPSHOT-37d5b38_checksums.txt 
   rw-r--r--   1      2 MiB   Mon Dec 11 21:36:14 2023    rye_Darwin_arm64.tar.gz 
   rw-r--r--   1      2 MiB   Mon Dec 11 21:36:14 2023    rye_Darwin_x86_64.tar.gz 
   rw-r--r--   1      2 MiB   Mon Dec 11 21:36:14 2023    rye_Js_wasm.tar.gz 
   rw-r--r--   1      2 MiB   Mon Dec 11 21:36:14 2023    rye_Linux_arm64.tar.gz 
   rw-r--r--   1      2 MiB   Mon Dec 11 21:36:14 2023    rye_Linux_armv6.tar.gz 
   rw-r--r--   1      2 MiB   Mon Dec 11 21:36:14 2023    rye_Linux_x86_64.tar.gz 

$ file dist/*/*
dist/rye_darwin_amd64_v1/rye: Mach-O 64-bit executable x86_64
dist/rye_darwin_arm64/rye:    Mach-O 64-bit executable arm64
dist/rye_js_wasm/rye.wasm:    WebAssembly (wasm) binary module version 0x1 (MVP)
dist/rye_linux_amd64_v1/rye:  ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=BvkyllO9DKmgwBGw0okp/9IOzaQMcqQ-k88TjCM2M/Jhaq0mPRyttI0A4WFxp_/ojk6qBIr7KOw0HW2whMO, stripped
dist/rye_linux_arm64/rye:     ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=vmfqvDNbY2h5zk2J8PwK/kIYy91BtT26RR-C_1Zbi/CY9fVpG6uG9cKo3MsY04/OTR_gTyQncuzKsKqGQcm, stripped
dist/rye_linux_arm_6/rye:     ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=x0s6M4TlcA7AmatTvVsW/gYSOcnpJ_0SPcMRt_xLK/YImtxyrfJyicKiF45GRj/AZjD675TuYqjMxT1oOw0, stripped
````