### PR TITLE
Custom tags for wasm release builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,7 +34,14 @@ builds:
       #   goarch: arm
 
     flags:
-    - -tags=b_tiny,b_norepl
+    - -tags=b_tiny
+
+    overrides:
+    - goarch: wasm
+      goos: js
+      flags:
+      - -tags=b_tiny,b_norepl
+
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
Feel free to adjust tags as needed. Just note that cross platform Go builds are not possible to do for features requiring C bindings (CGO). There are workarounds, but likely not needed: https://goreleaser.com/cookbooks/cgo-and-crosscompiling/