### PR TITLE
Add ebitengine game of life example

### DIFF
--- a/examples/ebitengine/life.rye
+++ b/examples/ebitengine/life.rye
@@ -1,0 +1,86 @@
+w: 320
+h: 240
+
+maxInitAliveCells: w * h / 10
+
+world: list produce w * h { } { .concat false }
+
+loop maxInitAliveCells {
+    x: random-integer w
+    y: random-integer h
+    change\nth! world 1 + x + y * w true
+}
+
+pixels: list produce w * h * 4 { } { .concat 0 }
+
+
+neighbourCount: fn { x y } {
+    c: 0
+    neg: 0 - 1 ; TODO loading literal -1 doesn't work
+    ixs: vals { neg 0 1 }
+    for ixs { :i
+        for ixs { :j
+            if any { not i = 0 not j = 0 } {
+                x2: x + i
+                y2: y + j
+                if all { not x2 < 0 not y2 < 0 not w <= x2 not h <= y2 } {
+                    if world .nth 1 + x2 + y2 * w {
+                        inc! 'c
+                    }
+                }
+            }
+        }
+    }
+    return c
+}
+
+on-update {
+    print "on-update"
+    next: list produce w * h { } { .concat false }
+
+    loop w { :x1
+        x: x1 - 1
+        loop h { :y1
+            y: y1 - 1
+            pop: neighbourCount x y
+            ix: 1 + x + y * w
+            either pop < 2 {
+                change\nth! next ix false
+            } {
+                either all { any { pop = 2 pop = 3 } world .nth ix } {
+                    change\nth! next ix true
+                } {
+                    either pop > 3 {
+                        change\nth! next ix false
+                    } { if pop = 3 {
+                        change\nth! next ix true } 
+                    }
+                } 
+            } 
+        }
+    }
+    world: next
+}
+
+on-draw { :screen
+    print "on-draw"
+    loop w * h { :i1
+        i: i1 - 1
+        ix: 1 + i * 4
+        either world .nth 1 + i {
+            change\nth! pixels ix 255
+            change\nth! pixels ix + 1 255
+            change\nth! pixels ix + 2 255
+            change\nth! pixels ix + 3 255
+        } {
+            change\nth! pixels ix 0
+            change\nth! pixels ix + 1 0
+            change\nth! pixels ix + 2 0
+            change\nth! pixels ix + 3 0
+        }
+    }
+    
+    screen .write-pixels pixels
+}
+
+ebitengine-run w h

--- a/tests/builtins.rye
+++ b/tests/builtins.rye
@@ -1226,6 +1226,19 @@ section "Functions that change values in-place"
 		equal { b: { 1 2 3 } , append! { 4 5 } 'b , b } { 1 2 3 { 4 5 } }
 	}
 
+	group "change\ nth!"
+	mold\nowrap ?change\nth!
+	{ { word } { object } }
+	{
+		equal { b: { 1 2 3 } , change\nth! b 2 4 } { 1 4 3 }
+		equal { b: { 1 2 3 } , change\nth! b 2 { 4 5 } } { 1 { 4 5 } 3 }
+		equal { b: list { 1 2 3 } , change\nth! b 2 4 } list { 1 4 3 }
+		equal { b: list { 1 2 3 } , change\nth! b 2 list { 4 5 } } list vals { 1 list { 4 5 } 3 }
+		equal { try { b: { 1 2 3 } , change\nth! b 4 0 } |type? } 'error
+		equal { try { b: list { 1 2 3 } , change\nth! b 4 0 } |type? } 'error
+	}
+	
+
 	group "sort!"
 	mold\nowrap ?append!
 	{ { word } { object } }


### PR DESCRIPTION
This PR adds an ebitengine game of life example. It runs very slow and I think it could be useful to use as a benchmark for optimizations.

Also added two new built in functions `random-integer` and `change\\nth!` needed for the example.

Depends on changes in https://github.com/refaktor/rye-contrib/pull/2