### PR TITLE
Fix module path

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,7 @@ linters-settings:
       - pattern: 'interface{}'
         replacement: 'any'
   goimports:
-    local-prefixes: github.com/golangci/golangci-lint
+    local-prefixes: github.com/refaktor/rye
   gomnd:
     # don't include the "operation" and "assign"
     checks:
@@ -94,7 +94,7 @@ linters:
     # - gocritic
     # - gocyclo
     - gofmt
-    # - goimports
+    - goimports
     # - gomnd
     - goprintffuncname
     - gosec

--- a/evaldo/builtins.go
+++ b/evaldo/builtins.go
@@ -10,16 +10,18 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
-	"rye/env"
-	"rye/term"
 	"sort"
 
-	"rye/loader"
-	// JM 20230825	"rye/term"
-	"rye/util"
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/term"
+
+	"github.com/refaktor/rye/loader"
+	// JM 20230825	"github.com/refaktor/rye/term"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/refaktor/rye/util"
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/text/cases"

--- a/evaldo/builtins_bcrypt.go
+++ b/evaldo/builtins_bcrypt.go
@@ -6,7 +6,8 @@ package evaldo
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 
 	"golang.org/x/crypto/bcrypt"
 )

--- a/evaldo/builtins_bcrypt_not.go
+++ b/evaldo/builtins_bcrypt_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_bcrypt = map[string]*env.Builtin{}

--- a/evaldo/builtins_bson.go
+++ b/evaldo/builtins_bson.go
@@ -5,7 +5,8 @@ package evaldo
 
 import (
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 
 	"github.com/drewlanenga/govector"
 	"go.mongodb.org/mongo-driver/bson"

--- a/evaldo/builtins_bson_not.go
+++ b/evaldo/builtins_bson_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_bson = map[string]*env.Builtin{}

--- a/evaldo/builtins_cayley.go
+++ b/evaldo/builtins_cayley.go
@@ -5,7 +5,8 @@ package evaldo
 
 import (
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 
 	"github.com/cayleygraph/cayley"
 	"github.com/cayleygraph/cayley/graph"

--- a/evaldo/builtins_cayley_not.go
+++ b/evaldo/builtins_cayley_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_cayley = map[string]*env.Builtin{}

--- a/evaldo/builtins_conversion.go
+++ b/evaldo/builtins_conversion.go
@@ -1,7 +1,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 // Integer represents an integer.

--- a/evaldo/builtins_crypto.go
+++ b/evaldo/builtins_crypto.go
@@ -7,7 +7,8 @@ import (
 	"crypto/ed25519"
 	"crypto/sha512"
 	"encoding/hex"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 )
 
 /* Our strategy to only support signed files

--- a/evaldo/builtins_crypto_not.go
+++ b/evaldo/builtins_crypto_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_crypto = map[string]*env.Builtin{}

--- a/evaldo/builtins_email.go
+++ b/evaldo/builtins_email.go
@@ -4,8 +4,9 @@
 package evaldo
 
 import (
-	"rye/env"
 	"strings"
+
+	"github.com/refaktor/rye/env"
 
 	"github.com/go-gomail/gomail"
 )

--- a/evaldo/builtins_email_not.go
+++ b/evaldo/builtins_email_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_email = map[string]*env.Builtin{}

--- a/evaldo/builtins_eyr.go
+++ b/evaldo/builtins_eyr.go
@@ -4,7 +4,8 @@ package evaldo
 import (
 	"fmt"
 	"os"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 )
 
 // definiraj frame <builtin nargs arg0 arg1>

--- a/evaldo/builtins_goroutines.go
+++ b/evaldo/builtins_goroutines.go
@@ -7,8 +7,9 @@ package evaldo
 
 import (
 	"fmt"
-	"rye/env"
 	"time"
+
+	"github.com/refaktor/rye/env"
 
 	"github.com/jinzhu/copier"
 )

--- a/evaldo/builtins_goroutines_not.go
+++ b/evaldo/builtins_goroutines_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_goroutines = map[string]*env.Builtin{}

--- a/evaldo/builtins_gtk.go
+++ b/evaldo/builtins_gtk.go
@@ -6,7 +6,7 @@ package evaldo
 import "C"
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 
 	"github.com/gotk3/gotk3/gtk"
 )

--- a/evaldo/builtins_gtk_not.go
+++ b/evaldo/builtins_gtk_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_gtk = map[string]*env.Builtin{}

--- a/evaldo/builtins_html.go
+++ b/evaldo/builtins_html.go
@@ -5,7 +5,8 @@ package evaldo
 
 import (
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 
 	"golang.org/x/net/html"
 

--- a/evaldo/builtins_html_not.go
+++ b/evaldo/builtins_html_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_html = map[string]*env.Builtin{}

--- a/evaldo/builtins_http.go
+++ b/evaldo/builtins_http.go
@@ -12,8 +12,9 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
-	"rye/env"
 	"strings"
+
+	"github.com/refaktor/rye/env"
 
 	//"time"
 	//"golang.org/x/time/rate"

--- a/evaldo/builtins_http_not.go
+++ b/evaldo/builtins_http_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_http = map[string]*env.Builtin{}

--- a/evaldo/builtins_io.go
+++ b/evaldo/builtins_io.go
@@ -12,9 +12,10 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"rye/env"
 	"strings"
 	"time"
+
+	"github.com/refaktor/rye/env"
 
 	"net/http"
 	"net/http/cgi"

--- a/evaldo/builtins_io_not.go
+++ b/evaldo/builtins_io_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_io = map[string]*env.Builtin{}

--- a/evaldo/builtins_json.go
+++ b/evaldo/builtins_json.go
@@ -6,9 +6,10 @@ package evaldo
 import (
 	"encoding/json"
 	"fmt"
-	"rye/env"
 	"strconv"
 	"strings"
+
+	"github.com/refaktor/rye/env"
 )
 
 func _emptyRM() env.Dict {

--- a/evaldo/builtins_json_not.go
+++ b/evaldo/builtins_json_not.go
@@ -5,8 +5,9 @@ package evaldo
 
 import (
 	"fmt"
-	"rye/env"
 	"strconv"
+
+	"github.com/refaktor/rye/env"
 )
 
 func _emptyRM() env.Dict {

--- a/evaldo/builtins_mail.go
+++ b/evaldo/builtins_mail.go
@@ -5,7 +5,8 @@ package evaldo
 
 import (
 	"io"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 
 	"github.com/thomasberger/parsemail"
 )

--- a/evaldo/builtins_mail_not.go
+++ b/evaldo/builtins_mail_not.go
@@ -3,6 +3,6 @@
 
 package evaldo
 
-import "rye/env"
+import "github.com/refaktor/rye/env"
 
 var Builtins_mail = map[string]*env.Builtin{}

--- a/evaldo/builtins_mime-mail_more-raw.go
+++ b/evaldo/builtins_mime-mail_more-raw.go
@@ -14,8 +14,9 @@ import (
 	"mime/multipart"
 	"mime/quotedprintable"
 	"net/mail"
-	"rye/env"
 	"strings"
+
+	"github.com/refaktor/rye/env"
 	// "github.com/jinzhu/copier"
 )
 

--- a/evaldo/builtins_mysql.go
+++ b/evaldo/builtins_mysql.go
@@ -8,7 +8,8 @@ package evaldo
 import (
 	"database/sql"
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 
 	_ "github.com/go-sql-driver/mysql"
 )

--- a/evaldo/builtins_mysql_not.go
+++ b/evaldo/builtins_mysql_not.go
@@ -7,7 +7,7 @@ package evaldo
 
 import (
 	//"database/sql"
-	"rye/env"
+	"github.com/refaktor/rye/env"
 	//"fmt"
 	//"strconv"
 	//"strings"

--- a/evaldo/builtins_nats.go
+++ b/evaldo/builtins_nats.go
@@ -7,7 +7,8 @@ import "C"
 
 import (
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 
 	nats "github.com/nats-io/nats.go"
 )

--- a/evaldo/builtins_nats_not.go
+++ b/evaldo/builtins_nats_not.go
@@ -5,7 +5,8 @@ package evaldo
 
 import (
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 )
 
 func strimp() { fmt.Println("") }

--- a/evaldo/builtins_nng.go
+++ b/evaldo/builtins_nng.go
@@ -7,7 +7,7 @@ import "C"
 
 import (
 	//	"fmt"
-	"rye/env"
+	"github.com/refaktor/rye/env"
 
 	"go.nanomsg.org/mangos"
 

--- a/evaldo/builtins_nng_not.go
+++ b/evaldo/builtins_nng_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_nng = map[string]*env.Builtin{}

--- a/evaldo/builtins_psql.go
+++ b/evaldo/builtins_psql.go
@@ -8,7 +8,8 @@ package evaldo
 import (
 	"database/sql"
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 
 	_ "github.com/lib/pq"
 )

--- a/evaldo/builtins_psql_not.go
+++ b/evaldo/builtins_psql_not.go
@@ -7,7 +7,7 @@ package evaldo
 
 import (
 	//"database/sql"
-	"rye/env"
+	"github.com/refaktor/rye/env"
 	//"fmt"
 	//"strconv"
 	//"strings"

--- a/evaldo/builtins_psutil.go
+++ b/evaldo/builtins_psutil.go
@@ -5,7 +5,8 @@ package evaldo
 
 import (
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 
 	"github.com/shirou/gopsutil/process"
 

--- a/evaldo/builtins_psutil_not.go
+++ b/evaldo/builtins_psutil_not.go
@@ -5,7 +5,8 @@ package evaldo
 
 import (
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 	//	"github.com/shirou/gopsutil/process"
 	//	"github.com/shirou/gopsutil/mem"
 )

--- a/evaldo/builtins_qframe.go
+++ b/evaldo/builtins_qframe.go
@@ -6,8 +6,9 @@ package evaldo
 import (
 	"fmt"
 	"io"
-	"rye/env"
 	"strconv"
+
+	"github.com/refaktor/rye/env"
 
 	"github.com/tobgu/qframe"
 	"github.com/tobgu/qframe/config/groupby"

--- a/evaldo/builtins_qframe_not.go
+++ b/evaldo/builtins_qframe_not.go
@@ -8,7 +8,7 @@ import (
 	//	"fmt"
 	//	"io"
 	//	"os"
-	"rye/env"
+	"github.com/refaktor/rye/env"
 	// "strconv"
 	// "strings"
 )

--- a/evaldo/builtins_raylib.go
+++ b/evaldo/builtins_raylib.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 
 	rl "github.com/gen2brain/raylib-go/raylib"
 )

--- a/evaldo/builtins_raylib_not.go
+++ b/evaldo/builtins_raylib_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_raylib = map[string]*env.Builtin{}

--- a/evaldo/builtins_regexp.go
+++ b/evaldo/builtins_regexp.go
@@ -2,7 +2,8 @@ package evaldo
 
 import (
 	"regexp"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_regexp = map[string]*env.Builtin{

--- a/evaldo/builtins_smtpd.go
+++ b/evaldo/builtins_smtpd.go
@@ -6,7 +6,8 @@ package evaldo
 import (
 	"bytes"
 	"net"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 
 	"github.com/jinzhu/copier"
 	"github.com/mhale/smtpd"

--- a/evaldo/builtins_smtpd_not.go
+++ b/evaldo/builtins_smtpd_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_smtpd = map[string]*env.Builtin{}

--- a/evaldo/builtins_spreadsheet.go
+++ b/evaldo/builtins_spreadsheet.go
@@ -5,11 +5,12 @@ package evaldo
 import (
 	"encoding/csv"
 	"os"
-	"rye/env"
-	"rye/util"
 	"slices"
 	"sort"
 	"strconv"
+
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/util"
 )
 
 var Builtins_spreadsheet = map[string]*env.Builtin{

--- a/evaldo/builtins_sqlite.go
+++ b/evaldo/builtins_sqlite.go
@@ -7,7 +7,8 @@ import "C"
 
 import (
 	"database/sql"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 
 	"fmt"
 	"strconv"

--- a/evaldo/builtins_sqlite_not.go
+++ b/evaldo/builtins_sqlite_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_sqlite = map[string]*env.Builtin{}

--- a/evaldo/builtins_stackless.go
+++ b/evaldo/builtins_stackless.go
@@ -3,7 +3,8 @@ package evaldo
 
 import (
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 )
 
 // definiraj frame <builtin nargs arg0 arg1>

--- a/evaldo/builtins_structures.go
+++ b/evaldo/builtins_structures.go
@@ -2,7 +2,8 @@ package evaldo
 
 import (
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 )
 
 // { <key> [ .print ] }

--- a/evaldo/builtins_sxml.go
+++ b/evaldo/builtins_sxml.go
@@ -5,7 +5,8 @@ package evaldo
 
 import (
 	"encoding/xml"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 
 	"fmt"
 	"io"

--- a/evaldo/builtins_sxml_not.go
+++ b/evaldo/builtins_sxml_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 //

--- a/evaldo/builtins_telegrambot.go
+++ b/evaldo/builtins_telegrambot.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 
 	tgm "github.com/go-telegram-bot-api/telegram-bot-api"
 )

--- a/evaldo/builtins_telegrambot_not.go
+++ b/evaldo/builtins_telegrambot_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 /*

--- a/evaldo/builtins_test.go
+++ b/evaldo/builtins_test.go
@@ -4,8 +4,9 @@ package evaldo
 
 import (
 	"fmt"
-	"rye/env"
-	"rye/loader"
+
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/loader"
 
 	//"fmt"
 	"testing"

--- a/evaldo/builtins_validation.go
+++ b/evaldo/builtins_validation.go
@@ -6,11 +6,12 @@ package evaldo
 import (
 	"fmt"
 	"net/mail"
-	"rye/env"
-	"rye/util"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/util"
 )
 
 // Integer represents an integer.

--- a/evaldo/builtins_validation_not.go
+++ b/evaldo/builtins_validation_not.go
@@ -6,8 +6,8 @@ package evaldo
 import (
 	"fmt"
 	//	"net/mail"
-	"rye/env"
-	// "rye/util"
+	"github.com/refaktor/rye/env"
+	// "github.com/refaktor/rye/util"
 	"strconv"
 	"strings"
 	"time"

--- a/evaldo/builtins_vector.go
+++ b/evaldo/builtins_vector.go
@@ -1,7 +1,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 
 	"github.com/drewlanenga/govector"
 )

--- a/evaldo/builtins_web.go
+++ b/evaldo/builtins_web.go
@@ -7,8 +7,9 @@ import "C"
 
 import (
 	"fmt"
-	"rye/env"
 	"strconv"
+
+	"github.com/refaktor/rye/env"
 
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo"

--- a/evaldo/builtins_web_not.go
+++ b/evaldo/builtins_web_not.go
@@ -6,7 +6,7 @@ package evaldo
 // import "C"
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var OutBuffer = "" // how does this work with multiple threads / ... in server use ... probably we would need some per environment variable, not global / global?

--- a/evaldo/builtins_webview.go
+++ b/evaldo/builtins_webview.go
@@ -14,8 +14,9 @@ import (
 	"net"
 	"net/http"
 	"path/filepath"
-	"rye/env"
-	"rye/util"
+
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/util"
 
 	"github.com/webview/webview"
 )

--- a/evaldo/builtins_webview_not.go
+++ b/evaldo/builtins_webview_not.go
@@ -4,7 +4,7 @@
 package evaldo
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 var Builtins_webview = map[string]*env.Builtin{}

--- a/evaldo/evaldo.go
+++ b/evaldo/evaldo.go
@@ -2,7 +2,8 @@ package evaldo
 
 import (
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 	//"fmt"
 	//"strconv"
 )

--- a/evaldo/evaldo_fn_test.go
+++ b/evaldo/evaldo_fn_test.go
@@ -2,8 +2,8 @@
 package evaldo
 
 import (
-	"rye/env"
-	"rye/loader"
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/loader"
 
 	"fmt"
 

--- a/evaldo/evaldo_op_test.go
+++ b/evaldo/evaldo_op_test.go
@@ -2,8 +2,8 @@
 package evaldo
 
 import (
-	"rye/env"
-	"rye/loader"
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/loader"
 
 	"fmt"
 

--- a/evaldo/evaldo_test.go
+++ b/evaldo/evaldo_test.go
@@ -3,8 +3,9 @@ package evaldo
 
 import (
 	"fmt"
-	"rye/env"
-	"rye/loader"
+
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/loader"
 
 	"testing"
 )

--- a/evaldo/generic.go
+++ b/evaldo/generic.go
@@ -1,8 +1,8 @@
 package evaldo
 
 import (
-	"rye/env"
-	//"rye/loader"
+	"github.com/refaktor/rye/env"
+	//"github.com/refaktor/rye/loader"
 )
 
 func registerGeneric(ps *env.ProgramState, kind int, word int, object env.Object) {

--- a/evaldo/repl.go
+++ b/evaldo/repl.go
@@ -9,9 +9,10 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"rye/env"
-	"rye/loader"
 	"strings"
+
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/loader"
 
 	"github.com/refaktor/liner"
 )

--- a/evaldo/repl_not.go
+++ b/evaldo/repl_not.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 
 	//	"regexp"
-	"rye/env"
-	//	"rye/loader"
+	"github.com/refaktor/rye/env"
+	//	"github.com/refaktor/rye/loader"
 	//	"strings"
 	//	"github.com/refaktor/liner"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module rye
+module github.com/refaktor/rye
 
 go 1.21
 

--- a/loader/load_spruce.go
+++ b/loader/load_spruce.go
@@ -3,7 +3,8 @@ package loader
 
 import (
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 )
 
 /*

--- a/loader/load_spruce_test.go
+++ b/loader/load_spruce_test.go
@@ -2,7 +2,8 @@ package loader
 
 import (
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 
 	//"fmt"
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"rye/env"
+	"github.com/refaktor/rye/env"
 
 	//. "github.com/yhirose/go-peg"
 	//. "github.com/CWood1/go-peg"

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2,7 +2,8 @@ package loader
 
 import (
 	"fmt"
-	"rye/env"
+
+	"github.com/refaktor/rye/env"
 
 	//"fmt"
 	"testing"

--- a/main.go
+++ b/main.go
@@ -7,7 +7,8 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
-	"rye/contrib"
+
+	"github.com/refaktor/rye/contrib"
 
 	"bufio"
 	"errors"
@@ -18,10 +19,11 @@ import (
 	"strings"
 
 	"net/http"
-	"rye/env"
-	"rye/evaldo"
-	"rye/loader"
-	"rye/util"
+
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/evaldo"
+	"github.com/refaktor/rye/loader"
+	"github.com/refaktor/rye/util"
 
 	"net/http/cgi"
 )

--- a/main_wasm.go
+++ b/main_wasm.go
@@ -5,11 +5,12 @@ package main
 
 import (
 	"fmt"
-	"rye/contrib"
-	"rye/env"
-	"rye/evaldo"
-	"rye/loader"
 	"syscall/js"
+
+	"github.com/refaktor/rye/contrib"
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/evaldo"
+	"github.com/refaktor/rye/loader"
 )
 
 type TagType int

--- a/term/term.go
+++ b/term/term.go
@@ -5,10 +5,11 @@ package term
 
 import (
 	"fmt"
-	"rye/env"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/refaktor/rye/env"
 
 	"github.com/pkg/term"
 )

--- a/term/term_wasm.go
+++ b/term/term_wasm.go
@@ -4,7 +4,7 @@
 package term
 
 import (
-	"rye/env"
+	"github.com/refaktor/rye/env"
 )
 
 // DisplayBlock is dummy non-implementation for wasm for display builtin

--- a/tests/go_tests/contexts/contexts_test.go
+++ b/tests/go_tests/contexts/contexts_test.go
@@ -2,10 +2,11 @@ package contexts
 
 import (
 	"fmt"
-	"rye/env"
-	"rye/evaldo"
-	"rye/loader"
 	"testing"
+
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/evaldo"
+	"github.com/refaktor/rye/loader"
 )
 
 func TestContexts_1(t *testing.T) {

--- a/tests/go_tests/failures/failures_error_test.go
+++ b/tests/go_tests/failures/failures_error_test.go
@@ -1,10 +1,11 @@
 package failures
 
 import (
-	"rye/env"
-	"rye/evaldo"
-	"rye/loader"
 	"testing"
+
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/evaldo"
+	"github.com/refaktor/rye/loader"
 )
 
 func TestFailures_no_error1(t *testing.T) {

--- a/tests/go_tests/failures/failures_failure_test.go
+++ b/tests/go_tests/failures/failures_failure_test.go
@@ -2,9 +2,10 @@ package failures
 
 import (
 	"fmt"
-	"rye/env"
-	"rye/evaldo"
-	"rye/loader"
+
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/evaldo"
+	"github.com/refaktor/rye/loader"
 
 	//	"fmt"
 	"testing"

--- a/tests/go_tests/failures/failures_return_test.go
+++ b/tests/go_tests/failures/failures_return_test.go
@@ -2,9 +2,10 @@ package failures
 
 import (
 	"fmt"
-	"rye/env"
-	"rye/evaldo"
-	"rye/loader"
+
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/evaldo"
+	"github.com/refaktor/rye/loader"
 
 	//	"fmt"
 	"testing"

--- a/tests/go_tests/perf/perf2_test.go
+++ b/tests/go_tests/perf/perf2_test.go
@@ -1,9 +1,9 @@
 package perf
 
 import (
-	"rye/env"
-	"rye/evaldo"
-	"rye/loader"
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/evaldo"
+	"github.com/refaktor/rye/loader"
 
 	//	"fmt"
 	"testing"

--- a/tests/go_tests/perf/perf_test.go
+++ b/tests/go_tests/perf/perf_test.go
@@ -1,10 +1,11 @@
 package perf
 
 import (
-	"rye/env"
-	"rye/evaldo"
-	"rye/loader"
 	"testing"
+
+	"github.com/refaktor/rye/env"
+	"github.com/refaktor/rye/evaldo"
+	"github.com/refaktor/rye/loader"
 )
 
 /*

--- a/util/util.go
+++ b/util/util.go
@@ -4,9 +4,10 @@ package util
 import (
 	"fmt"
 	"regexp"
-	"rye/env"
 	"strconv"
 	"strings"
+
+	"github.com/refaktor/rye/env"
 )
 
 func PrintHeader() {


### PR DESCRIPTION
Rename module `rye` -> `github.com/refaktor/rye`

to be valid, eg https://pkg.go.dev/github.com/refaktor/rye@v0.0.9 reports
> "github.com/refaktor/rye" does not have a valid module path ("rye").

Requires
* https://github.com/refaktor/rye-contrib/pull/3