### PR TITLE
webview -> webview_go, ci build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,15 @@ jobs:
       with:
         go-version: '1.21'
 
+    - name: Install cgo dependancies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+
     - name: Build
       # Enable all features for CI builds. 
-      # TODO: add currently problematic tags: b_cayley,b_gtk,b_nng,b_qframe,b_raylib,b_webview,b_ebitengine
-      run: go build -v -tags "b_sqlite,b_http,b_sql,b_postgres,b_bson,b_crypto,b_smtpd,b_mail,b_bcrypt,b_telegram,b_html,b_contrib,b_openai,b_email,b_mail,b_mysql,b_nats,b_psql,b_psutil,b_sxml,b_echo" -o bin/rye
+      # TODO: add currently problematic tags: b_cayley,b_gtk,b_nng,b_qframe,b_raylib,b_ebitengine
+      run: go build -v -tags "b_sqlite,b_http,b_sql,b_postgres,b_bson,b_crypto,b_smtpd,b_mail,b_bcrypt,b_telegram,b_html,b_contrib,b_openai,b_email,b_mail,b_mysql,b_nats,b_psql,b_psutil,b_sxml,b_echo,b_webview" -o bin/rye
 
     - name: Run Rye Tests
       run: cd tests ; ../bin/rye main.rye test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install cgo dependancies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+        sudo apt-get install -y libwebkit2gtk-4.0-dev # for webview
 
     - name: Build
       # Enable all features for CI builds. 

--- a/evaldo/builtins_webview.go
+++ b/evaldo/builtins_webview.go
@@ -15,10 +15,10 @@ import (
 	"net/http"
 	"path/filepath"
 
+	webview "github.com/webview/webview_go"
+
 	"github.com/refaktor/rye/env"
 	"github.com/refaktor/rye/util"
-
-	"github.com/webview/webview"
 )
 
 var Builtins_webview = map[string]*env.Builtin{

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/thomasberger/parsemail v1.2.6
 	github.com/tobgu/qframe v0.4.0
-	github.com/webview/webview v0.0.0-20230830165049-e0ca3ed53345
+	github.com/webview/webview_go v0.0.0-20230901181450-5a14030a9070
 	go.mongodb.org/mongo-driver v1.13.0
 	go.nanomsg.org/mangos v2.0.0+incompatible
 	golang.org/x/crypto v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -438,8 +438,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
-github.com/webview/webview v0.0.0-20230830165049-e0ca3ed53345 h1:Yd7JTBOgDe3RoYuQTsSgLw0K8SN8VBZrYY9AxnoGMpM=
-github.com/webview/webview v0.0.0-20230830165049-e0ca3ed53345/go.mod h1:rpXAuuHgyEJb6kXcXldlkOjU6y4x+YcASKKXJNUhh0Y=
+github.com/webview/webview_go v0.0.0-20230901181450-5a14030a9070 h1:imZLWyo1ondeQjqfb/eHuYgFiOAYg6ugSMCnGfPTPmg=
+github.com/webview/webview_go v0.0.0-20230901181450-5a14030a9070/go.mod h1:yE65LFCeWf4kyWD5re+h4XNvOHJEXOCOuJZ4v8l5sgk=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3kKLN4=
 github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=


### PR DESCRIPTION
Use Go-specific module https://github.com/webview/webview_go
instead of https://github.com/webview/webview
which lost Go support since:
* https://github.com/webview/webview/pull/1009
* https://github.com/webview/webview/issues/1010

I made it build in the CI pipeline and locally, but didn't run it locally, so please test it.