### PR TITLE
CI: Don't install unnecessary dependancies for raylib & gtk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,16 +41,16 @@ jobs:
         # sudo apt-get install -y libc6-dev libgl1-mesa-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev libxxf86vm-dev libasound2-dev pkg-config
 
         # raylib: https://github.com/gen2brain/raylib-go/blob/master/.github/workflows/build.yml
-        sudo apt-get install -y libxi-dev libxinerama-dev libxcursor-dev libxrandr-dev libgl1-mesa-dev
+        # sudo apt-get install -y libxi-dev libxinerama-dev libxcursor-dev libxrandr-dev libgl1-mesa-dev
 
         # gtk: https://github.com/gotk3/gotk3/blob/master/.github/workflows/linux.yml
-        sudo apt-get install -y libgtk-3-dev libcairo2-dev libglib2.0-dev
+        # sudo apt-get install -y libgtk-3-dev libcairo2-dev libglib2.0-dev
 
     - name: Install MacOS cgo dependancies
       if: runner.os == 'macOS'
       run: |
         # b_gtk: https://github.com/gotk3/gotk3/blob/master/.github/workflows/macos.yml
-        brew install gobject-introspection gtk+3  
+        # brew install gobject-introspection gtk+3  
 
     - name: Build
       # Enable all features for CI builds. 


### PR DESCRIPTION
Not needed anymore since 410b2839ed70e835221e45362014e8c8b3593413, see:  https://github.com/refaktor/rye/commit/410b2839ed70e835221e45362014e8c8b3593413#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L59-R59