### PR TITLE
ci: Disable unnecessary apt update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,8 @@ jobs:
     - name: Install Linux cgo dependancies
       if: runner.os == 'Linux'
       run: |
-        sudo apt-get update
+        # sudo apt-get update
+
         # webview https://github.com/webview/webview_go/blob/master/.github/workflows/ci.yaml
         sudo apt-get install -y libwebkit2gtk-4.0-dev
 


### PR DESCRIPTION
Not needed since #77, Linux builds should be faster.