### PR TITLE
Improve error messages

### DIFF
--- a/env/series.go
+++ b/env/series.go
@@ -107,10 +107,17 @@ func (ser TSeries) Len() int {
 func (ser TSeries) Probe(idxs Idxs) string {
 	var bu strings.Builder
 	bu.WriteString("{ ")
-	for i, v := range ser.S {
+	st := 0
+	if ser.Pos() > 10 {
+		bu.WriteString("... ")
+		st = ser.Pos() - 11
+	}
+	for i := st; i < ser.Pos()+9 && i < ser.Len(); i++ {
 		if i == ser.Pos()-1 {
-			bu.WriteString("<-here-> ")
+			bu.WriteString("\x1b[1m(here) \x1b[22m")
 		}
+
+		v := ser.S[i]
 		if v != nil {
 			bu.WriteString(v.Probe(idxs) + " ")
 		} else {
@@ -118,7 +125,10 @@ func (ser TSeries) Probe(idxs Idxs) string {
 		}
 	}
 	if ser.Len() == ser.Pos()-1 {
-		bu.WriteString("<-here-> ")
+		bu.WriteString("\x1b[1m(here)\x1b[22m")
+	}
+	if ser.Len() > ser.Pos()+9 {
+		bu.WriteString("... ")
 	}
 	bu.WriteString("}")
 	return bu.String()

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -83,8 +83,10 @@ func LoadString(input string, sig bool) (env.Object, *env.Idxs) {
 	input = removeBangLine(input)
 
 	inp1 := strings.TrimSpace(input)
+	var noBraces bool
 	if strings.Index("{", inp1) != 0 {
 		input = "{ " + input + " }"
+		noBraces = true
 	}
 
 	parser := newParser()
@@ -92,7 +94,19 @@ func LoadString(input string, sig bool) (env.Object, *env.Idxs) {
 
 	if err != nil {
 		fmt.Print("\x1b[35;3m")
-		fmt.Print(err.Error())
+		errStr := err.Error()
+		if noBraces {
+			// hacky way to remove the first and last curly braces and
+			// fix the error position without changing the parser library
+			errStr = strings.Replace(errStr, "{", "", 1)
+			if i := strings.LastIndex(errStr, "}"); i >= 0 {
+				errStr = errStr[:i] + errStr[i+1:]
+			}
+			if i := strings.LastIndex(errStr, "-"); i >= 0 {
+				errStr = errStr[:i] + errStr[i+1:]
+			}
+		}
+		fmt.Print(errStr)
 		fmt.Println("\x1b[0m")
 
 		empty1 := make([]env.Object, 0)


### PR DESCRIPTION
- bold (here) message
- only 10 surrounding tokens printed around the error location
- no implied currly braces in loader error message