### PR TITLE
ci: Sign release binaries and images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,17 @@ permissions:
 
 jobs:
   goreleaser:
+    outputs:
+      hashes: ${{ steps.binary.outputs.hashes }}
+      image: ${{ steps.image.outputs.name }}
+      digest: ${{ steps.image.outputs.digest }}
     runs-on: ubuntu-latest
 
     permissions:
       contents: write
       packages: write
       # issues: write
+      # id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +34,9 @@ jobs:
         with:
           go-version: stable
 
-      - uses: goreleaser/goreleaser-action@v5
+      - name: Run GoReleaser
+        id: goreleaser
+        uses: goreleaser/goreleaser-action@v5
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro':
           distribution: goreleaser
@@ -37,3 +44,110 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate binary hashes
+        id: binary
+        env:
+          ARTIFACTS: "${{ steps.goreleaser.outputs.artifacts }}"
+        run: |
+          set -euo pipefail
+
+          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+          echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+      - name: Image digest
+        id: image
+        env:
+          ARTIFACTS: "${{ steps.goreleaser.outputs.artifacts }}"
+        run: |
+          set -euo pipefail
+          image_and_digest=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Docker Manifest") | .path')
+          image=$(echo "${image_and_digest}" | cut -d'@' -f1 | cut -d':' -f1)
+          digest=$(echo "${image_and_digest}" | cut -d'@' -f2)
+          echo "name=$image" >> "$GITHUB_OUTPUT"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+  binary-provenance:
+    needs: [goreleaser]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
+    with:
+      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
+      upload-assets: true # upload to a new release
+
+  image-provenance:
+    needs: [goreleaser]
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.9.0
+    with:
+      image: ${{ needs.goreleaser.outputs.image }}
+      digest: ${{ needs.goreleaser.outputs.digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  verification-with-slsa-verifier:
+    needs: [goreleaser, binary-provenance]
+    runs-on: ubuntu-latest
+    permissions: read-all
+    steps:
+      - name: Install the verifier
+        uses: slsa-framework/slsa-verifier/actions/installer@v2.4.0
+
+      - name: Download assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROVENANCE: "${{ needs.binary-provenance.outputs.provenance-name }}"
+        run: |
+          set -euo pipefail
+          gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "*.tar.gz"
+          # gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "*.zip"
+          gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "$PROVENANCE"
+
+      - name: Verify assets
+        env:
+          CHECKSUMS: ${{ needs.goreleaser.outputs.hashes }}
+          PROVENANCE: "${{ needs.binary-provenance.outputs.provenance-name }}"
+        run: |
+          set -euo pipefail
+          checksums=$(echo "$CHECKSUMS" | base64 -d)
+          while read -r line; do
+              fn=$(echo $line | cut -d ' ' -f2)
+              echo "Verifying $fn"
+              slsa-verifier verify-artifact --provenance-path "$PROVENANCE" \
+                                            --source-uri "github.com/$GITHUB_REPOSITORY" \
+                                            --source-tag "$GITHUB_REF_NAME" \
+                                            "$fn"
+          done <<<"$checksums"
+
+  verification-with-cosign:
+    needs: [goreleaser, image-provenance]
+    runs-on: ubuntu-latest
+    permissions: read-all
+    steps:
+      - name: Login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Verify image
+        env:
+          IMAGE: ${{ needs.goreleaser.outputs.image }}
+          DIGEST: ${{ needs.goreleaser.outputs.digest }}
+        run: |
+          cosign verify-attestation \
+             --type slsaprovenance \
+             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+             --certificate-identity-regexp '^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
+             $IMAGE@$DIGEST

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,12 +35,14 @@ builds:
 
     flags:
     - -tags=b_tiny
+    - -trimpath
 
     overrides:
     - goarch: wasm
       goos: js
       flags:
       - -tags=b_tiny,b_norepl
+      - -trimpath
 
 
 archives:
@@ -69,6 +71,8 @@ kos:  # See https://goreleaser.com/customization/ko/
     - linux/amd64
     - linux/arm64
 
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
 changelog: # See https://goreleaser.com/customization/changelog/
   use: github
   sort: asc


### PR DESCRIPTION
Signing steps from example https://github.com/goreleaser/goreleaser-example-slsa-provenance applied to rye repo.

Tested in my fork, see:
* Test PR https://github.com/stefanb/rye/pull/12
* releases from test PR branch: https://github.com/stefanb/rye/releases
* images: https://github.com/stefanb/rye/pkgs/container/rye


Scorecard for my fork confirms that latest test releases are signed there: https://securityscorecards.dev/viewer/?uri=github.com/stefanb/rye
<img width="699" alt="image" src="https://github.com/refaktor/rye/assets/319826/2ea54ca3-a419-4285-aa1b-0f0efa2c2969">


---
Feel free to try squash-merge option when merging the PR:
<img width="371" alt="image" src="https://github.com/refaktor/rye/assets/319826/1b84a6f5-c9c7-45e0-911a-afc28b5ee100">
(if that option is not available you may need to enable it in repositroy settings)
