### PR TITLE
Adding support for list type in Intersection function and union fix

### DIFF
--- a/evaldo/builtins.go
+++ b/evaldo/builtins.go
@@ -4929,12 +4929,15 @@ var builtins = map[string]*env.Builtin{
 				switch secondBlock := arg1.(type) {
 				case env.Block:
 					mergedSlice := make([]env.Object, 0)
-					firtArgumentValue := s1
+					// Initially fill first block data
+					for _, v := range s1.Data {
+						mergedSlice = append(mergedSlice, env.ToRyeValue(v))
+					}
 					// If isAvailable is false then it is new value
 					isAvailable := false
 					for _, v1 := range secondBlock.Series.S {
 						isAvailable = false
-						for _, v2 := range firtArgumentValue.Data {
+						for _, v2 := range s1.Data {
 							if env.RyeToRaw(v1) == v2 {
 								isAvailable = true
 								break
@@ -4942,11 +4945,17 @@ var builtins = map[string]*env.Builtin{
 						}
 						// If new value then add in List
 						if !isAvailable {
-							s1.Data = append(s1.Data, env.RyeToRaw(v1))
+							mergedSlice = append(mergedSlice, v1)
 						}
 					}
-					mergedSlice = append(mergedSlice, s1)
-					return *env.NewBlock(*env.NewTSeries(mergedSlice))
+					// Create list of array
+					unionSlice := make([]any, 0, len(mergedSlice))
+					for _, value := range mergedSlice {
+						unionSlice = append(unionSlice, value)
+					}
+					// return List
+					return *env.NewList(unionSlice)
+
 				default:
 					return MakeArgError(ps, 2, []env.Type{env.BlockType}, "union")
 				}

--- a/evaldo/builtins.go
+++ b/evaldo/builtins.go
@@ -4979,9 +4979,29 @@ var builtins = map[string]*env.Builtin{
 				default:
 					return MakeArgError(ps, 2, []env.Type{env.BlockType}, "intersect")
 				}
-				// TODO-FIX1 add for list
+			case env.List:
+				switch secondBlock := arg1.(type) {
+				case env.Block:
+					commonSlice := make([]env.Object, 0)
+					for _, v1 := range s1.Data {
+						for _, v2 := range secondBlock.Series.S {
+							// get matching value in both blocks
+							if env.RyeToRaw(v2) == v1 {
+								commonSlice = append(commonSlice, v2)
+							}
+						}
+					}
+					intersectSlice := make([]any, 0, len(commonSlice))
+					for _, value := range commonSlice {
+						intersectSlice = append(intersectSlice, value)
+					}
+					// return List
+					return *env.NewList(intersectSlice)
+				default:
+					return MakeArgError(ps, 2, []env.Type{env.BlockType}, "intersect")
+				}
 			default:
-				return MakeArgError(ps, 1, []env.Type{env.StringType, env.BlockType}, "intersect")
+				return MakeArgError(ps, 1, []env.Type{env.StringType, env.BlockType, env.ListType}, "intersect")
 			}
 		},
 	},

--- a/tests/structures.rye
+++ b/tests/structures.rye
@@ -221,6 +221,10 @@ section "Working with blocks and lists"
 		equal { intersection { 1 3 5 6 } { 2 3 4 5 } } { 3 5 }
 		equal { intersection { } { 2 3 4  } } { }
 		equal { intersection { } { } } { }
+
+		equal { intersection list { 1 3 5 6 } { 2 3 4 5 } } list { 3 5 }
+		equal { intersection list { } { 2 3 4  } } list { }
+		equal { intersection list { } { } } list { }
 	}
 	group "unique"
 	mold\nowrap ?append!

--- a/tests/structures.rye
+++ b/tests/structures.rye
@@ -213,6 +213,11 @@ section "Working with blocks and lists"
 		equal { union { 8 2 } { 1 9 } |length? } 4 ; sortorder isn't deterministic so far ... think if it should be
 		equal { union { } { 1 9 } |length? }  2
 		equal { union { } { } } { }
+
+		equal { union list { 1 2 } { 1 2 3 4 } } list { 1 2 3 4 }
+		equal { union list { 1 2 } { 1 } } list { 1 2 }
+		equal { union list { 1 2 } { } } list { 1 2 }
+		equal { union list { } { } } list { }
 	}
   	group "intersection"
 	mold\nowrap ?intersection

--- a/tests/structures.rye
+++ b/tests/structures.rye
@@ -228,7 +228,7 @@ section "Working with blocks and lists"
 		equal { intersection { } { } } { }
 
 		equal { intersection list { 1 3 5 6 } { 2 3 4 5 } } list { 3 5 }
-		equal { intersection list { } { 2 3 4  } } list { }
+		equal { intersection list { } { 2 3 4 } } list { }
 		equal { intersection list { } { } } list { }
 	}
 	group "unique"


### PR DESCRIPTION
**Changes:**
1. Adding support for List in the Intersection function
2. Added test cases for the intersection list
3. Fixing logic for List of union. ( Previous logic was returning Block, we need a list  - realized after adding test cases)
4. Added test cases for list of union
5.  Both union and intersection list is working fine. tested with testcases and command line.
![image](https://github.com/refaktor/rye/assets/5825319/446a9783-6d34-40c0-8f8c-de4291e6c66e)
--
![image](https://github.com/refaktor/rye/assets/5825319/3b3f96ee-a191-4801-a706-6ba6439e9adc)

6. All assigned tasks are completed, Please provide the next task to start