### PR TITLE
Adding support for LIST Type in REVERSE! Function

### DIFF
--- a/evaldo/builtins.go
+++ b/evaldo/builtins.go
@@ -4578,7 +4578,7 @@ var builtins = map[string]*env.Builtin{
 				}
 				return *env.NewList(reverseList)
 			default:
-				return MakeArgError(ps, 1, []env.Type{env.BlockType, env.StringType}, "reverse")
+				return MakeArgError(ps, 1, []env.Type{env.BlockType, env.StringType, env.ListType}, "reverse!")
 			}
 		},
 	},

--- a/evaldo/builtins.go
+++ b/evaldo/builtins.go
@@ -4561,6 +4561,22 @@ var builtins = map[string]*env.Builtin{
 					reversed += string(s[i])
 				}
 				return *env.NewString(reversed)
+			case env.List:
+				// Create slice of env.Object
+				dataSlice := make([]env.Object, 0)
+				for _, v := range block.Data {
+					dataSlice = append(dataSlice, env.ToRyeValue(v))
+				}
+				// Reverse slice data
+				for left, right := 0, len(dataSlice)-1; left < right; left, right = left+1, right-1 {
+					dataSlice[left], dataSlice[right] = dataSlice[right], dataSlice[left]
+				}
+				// Create list frol slice data
+				reverseList := make([]any, 0, len(dataSlice))
+				for _, value := range dataSlice {
+					reverseList = append(reverseList, value)
+				}
+				return *env.NewList(reverseList)
 			default:
 				return MakeArgError(ps, 1, []env.Type{env.BlockType, env.StringType}, "reverse")
 			}

--- a/tests/misc.rye
+++ b/tests/misc.rye
@@ -242,9 +242,12 @@ section "Functions that change values in-place"
 	}
 	group "reverse!"
 	mold\nowrap ?append!
-	{ { word } { object } }
+	{ { word } { object } { list } }
 	{
 		equal { b: { 4 1 7 2 } , reverse! b , b } { 2 7 1 4 } ; TOTHINK -- should it accept tagword or block directly?
+		equal { reverse! list { 1 2 3 } } list { 3 2 1 }
+		equal { reverse! list { 1 } } list { 1 }
+		equal { reverse! list {  } } list {  }
 	}
 
 }


### PR DESCRIPTION
**Changes:**
1. Adding support for a list data type in reverse! function
2. Adding test cases for reverse! list function

**Testing:**
Checking with commands:
![image](https://github.com/refaktor/rye/assets/5825319/b2e7b000-f243-4c56-95b4-1807d68ecd7f)

Unit test case OK:
![image](https://github.com/refaktor/rye/assets/5825319/743ff35b-789f-483a-9b3f-1f4315c5551e)

