### PR TITLE
Implement evaluated block

### DIFF
--- a/evaldo/evaldo_test.go
+++ b/evaldo/evaldo_test.go
@@ -3,6 +3,7 @@ package evaldo
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/refaktor/rye/env"
 	"github.com/refaktor/rye/loader"
@@ -406,5 +407,47 @@ func TestEvaldo_load_lsetword4(t *testing.T) {
 
 	if es.Res.(env.Integer).Value != 80 {
 		t.Error("Expected result value 80")
+	}
+}
+
+func TestEvaldo_load_block(t *testing.T) {
+	input := "a: 1 { a 2 }"
+	block, genv := loader.LoadString(input, false)
+	es := env.NewProgramState(block.(env.Block).Series, genv)
+	RegisterBuiltins(es)
+
+	EvalBlock(es)
+
+	nonEvaluatedBlock := es.Res
+	if nonEvaluatedBlock.Type() != env.BlockType {
+		t.Error("Expected result type block")
+	}
+
+	if nonEvaluatedBlock.(env.Block).Series.Get(0).Type() != env.WordType {
+		t.Error("Expected first item to be evaluated to type integer but got type " + strconv.Itoa(int(nonEvaluatedBlock.(env.Block).Series.Get(0).Type())))
+	}
+	if nonEvaluatedBlock.(env.Block).Series.Get(1).Type() != env.IntegerType {
+		t.Error("Expected second item to be type integer")
+	}
+}
+
+func TestEvaldo_load_eval_block(t *testing.T) {
+	input := "a: 1 [ a 2 ]"
+	block, genv := loader.LoadString(input, false)
+	es := env.NewProgramState(block.(env.Block).Series, genv)
+	RegisterBuiltins(es)
+
+	EvalBlock(es)
+
+	evaluatedBlock := es.Res
+	if evaluatedBlock.Type() != env.BlockType {
+		t.Error("Expected result type block")
+	}
+
+	if evaluatedBlock.(env.Block).Series.Get(0).Type() != env.IntegerType {
+		t.Error("Expected first item to be evaluated to type integer but got type " + strconv.Itoa(int(evaluatedBlock.(env.Block).Series.Get(0).Type())))
+	}
+	if evaluatedBlock.(env.Block).Series.Get(1).Type() != env.IntegerType {
+		t.Error("Expected second item to be type integer")
 	}
 }

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/refaktor/rye/env"
 
@@ -250,6 +251,26 @@ func TestLoader_multiple_newlines2(t *testing.T) {
 	}
 	if block.(env.Block).Series.Get(4).Type() != env.IntegerType {
 		t.Error("Expected type integer")
+	}
+}
+
+func TestLoader_bblock(t *testing.T) {
+	input := "a: 1 [ a 2 ]"
+	block, _ := LoadString(input, false)
+	// expect setword, integer, block
+	if block.(env.Block).Series.Len() != 3 {
+		t.Error("Expected 3 items")
+	}
+	innerBlock := block.(env.Block).Series.Get(2)
+	if innerBlock.Type() != env.BlockType {
+		t.Error("Expected type block")
+	}
+	// block is not evaluated yet, only loaded
+	if innerBlock.(env.Block).Series.Get(0).Type() != env.WordType {
+		t.Error("Expected first item to be evaluated to type integer but got type " + strconv.Itoa(int(innerBlock.(env.Block).Series.Get(0).Type())))
+	}
+	if innerBlock.(env.Block).Series.Get(1).Type() != env.IntegerType {
+		t.Error("Expected second item to be type integer")
 	}
 }
 


### PR DESCRIPTION
This PR implements an evaluated block `[ ... ]` with the same semantics as evaluating a regular block `vals { ... }`. I used the existing loader `bblock` definition with `mode=1` for it.