### PR TITLE
[Adding math function] Support for Ceil, Cbrt functions

### DIFF
--- a/evaldo/builtins_math.go
+++ b/evaldo/builtins_math.go
@@ -313,6 +313,34 @@ var Builtins_math = map[string]*env.Builtin{
 			}
 		},
 	},
+	"ceil": {
+		Argsn: 1,
+		Doc:   "Returns the least integer value greater than or equal to x.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch val := arg0.(type) {
+			case env.Integer:
+				return *env.NewDecimal(math.Ceil(float64(val.Value)))
+			case env.Decimal:
+				return *env.NewDecimal(math.Ceil(val.Value))
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.DecimalType}, "ceil")
+			}
+		},
+	},
+	"cbrt": {
+		Argsn: 1,
+		Doc:   "Returns returns the cube root of x.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch val := arg0.(type) {
+			case env.Integer:
+				return *env.NewDecimal(math.Cbrt(float64(val.Value)))
+			case env.Decimal:
+				return *env.NewDecimal(math.Cbrt(val.Value))
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.DecimalType}, "cbrt")
+			}
+		},
+	},
 	"pi": {
 		Argsn: 0,
 		Doc:   "Return Pi constant.",

--- a/evaldo/builtins_math.go
+++ b/evaldo/builtins_math.go
@@ -319,7 +319,7 @@ var Builtins_math = map[string]*env.Builtin{
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
 			switch val := arg0.(type) {
 			case env.Integer:
-				return *env.NewDecimal(math.Ceil(float64(val.Value)))
+				return *env.NewDecimal(float64(val.Value))
 			case env.Decimal:
 				return *env.NewDecimal(math.Ceil(val.Value))
 			default:

--- a/tests/misc.rye
+++ b/tests/misc.rye
@@ -395,6 +395,22 @@ group "atanh"
 	{
 		equal { do\in math { atanh 0.5 } } 0.5493061443340548
 	}
+
+group "ceil"
+	mold\nowrap "" 
+	{ { string } }
+	{
+		equal { do\in math { ceil 5.7 } } 6.000000
+		equal { do\in math { ceil 4.9 } } 5.000000
+	}
+
+group "cbrt"
+	mold\nowrap "" 
+	{ { string } }
+	{
+		equal { do\in math { cbrt 27 } } 3.000000
+		equal { do\in math { cbrt 12.3 } } 2.308350239753609
+	}
 	
 }
 


### PR DESCRIPTION
**Changes:**
1. Adding support for Ceil and Cbrt function
2. Adding test cases

**Testing:**
![image](https://github.com/refaktor/rye/assets/5825319/cc88358c-dcde-4cf1-bb44-064162480d5c)

![image](https://github.com/refaktor/rye/assets/5825319/8977ad87-98bd-4697-9f87-0fafd432f01e)

test cases:
![image](https://github.com/refaktor/rye/assets/5825319/3500ffd7-2512-429e-82d8-b3293cd08bee)
