### PR TITLE
build and publish docker images through github CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,3 +151,28 @@ jobs:
              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
              --certificate-identity-regexp '^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
              $IMAGE@$DIGEST
+
+  docker-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+  
+      - name: Build Image
+        run: |
+          cp .docker/Dockerfile .
+          docker buildx build -t "refaktor/rye:latest" .
+          docker buildx build -t "refaktor/rye:${GITHUB_REF_NAME}" .
+
+      - name: Release
+        run: |
+          docker push "refaktor/rye:latest"
+          docker push "refaktor/rye:${GITHUB_REF_NAME}"
+  


### PR DESCRIPTION
I'm not sure if this is related to #194 but I don't see automation yet for publishing docker images, and wanted to contribute it.

Also not sure of a great way to test things like this, but feel free to grab me on discord (`@booniepepper`) if there are any issues