### PR TITLE
[Adding math functions] Support Erf, Erfc, Erfcinv and Erfinv math functions

### DIFF
--- a/evaldo/builtins_math.go
+++ b/evaldo/builtins_math.go
@@ -398,6 +398,20 @@ var Builtins_math = map[string]*env.Builtin{
 			}
 		},
 	},
+	"erf": {
+		Argsn: 1,
+		Doc:   "Returns the error function of value.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch val := arg0.(type) {
+			case env.Integer:
+				return *env.NewDecimal(math.Erf(float64(val.Value)))
+			case env.Decimal:
+				return *env.NewDecimal(math.Erf(val.Value))
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.DecimalType}, "erf")
+			}
+		},
+	},
 	"pi": {
 		Argsn: 0,
 		Doc:   "Return Pi constant.",

--- a/evaldo/builtins_math.go
+++ b/evaldo/builtins_math.go
@@ -412,6 +412,20 @@ var Builtins_math = map[string]*env.Builtin{
 			}
 		},
 	},
+	"erfc": {
+		Argsn: 1,
+		Doc:   "Returns the complementary error function of value.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch val := arg0.(type) {
+			case env.Integer:
+				return *env.NewDecimal(math.Erfc(float64(val.Value)))
+			case env.Decimal:
+				return *env.NewDecimal(math.Erfc(val.Value))
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.DecimalType}, "erfc")
+			}
+		},
+	},
 	"pi": {
 		Argsn: 0,
 		Doc:   "Return Pi constant.",

--- a/evaldo/builtins_math.go
+++ b/evaldo/builtins_math.go
@@ -432,17 +432,25 @@ var Builtins_math = map[string]*env.Builtin{
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
 			switch val := arg0.(type) {
 			case env.Integer:
-				if val.Value < 0 || val.Value > 2 {
-					return MakeBuiltinError(ps, "Invalid input: erfcinv is only defined for 0 <= x <= 2.", "erfcinv")
-				}
 				return *env.NewDecimal(math.Erfcinv(float64(val.Value)))
 			case env.Decimal:
-				if val.Value < 0 || val.Value > 2 {
-					return MakeBuiltinError(ps, "Invalid input: erfcinv is only defined for 0 <= x <= 2.", "erfcinv")
-				}
 				return *env.NewDecimal(math.Erfcinv(val.Value))
 			default:
 				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.DecimalType}, "erfcinv")
+			}
+		},
+	},
+	"erfinv": {
+		Argsn: 1,
+		Doc:   "Returns the inverse error function of value.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch val := arg0.(type) {
+			case env.Integer:
+				return *env.NewDecimal(math.Erfinv(float64(val.Value)))
+			case env.Decimal:
+				return *env.NewDecimal(math.Erfinv(val.Value))
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.DecimalType}, "erfinv")
 			}
 		},
 	},

--- a/evaldo/builtins_math.go
+++ b/evaldo/builtins_math.go
@@ -426,6 +426,26 @@ var Builtins_math = map[string]*env.Builtin{
 			}
 		},
 	},
+	"erfcinv": {
+		Argsn: 1,
+		Doc:   "Returns the inverse of erfc(x) function.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch val := arg0.(type) {
+			case env.Integer:
+				if val.Value < 0 || val.Value > 2 {
+					return MakeBuiltinError(ps, "Invalid input: erfcinv is only defined for 0 <= x <= 2.", "erfcinv")
+				}
+				return *env.NewDecimal(math.Erfcinv(float64(val.Value)))
+			case env.Decimal:
+				if val.Value < 0 || val.Value > 2 {
+					return MakeBuiltinError(ps, "Invalid input: erfcinv is only defined for 0 <= x <= 2.", "erfcinv")
+				}
+				return *env.NewDecimal(math.Erfcinv(val.Value))
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.DecimalType}, "erfcinv")
+			}
+		},
+	},
 	"pi": {
 		Argsn: 0,
 		Doc:   "Return Pi constant.",

--- a/tests/misc.rye
+++ b/tests/misc.rye
@@ -430,6 +430,40 @@ section "Math functions"
 		equal { do\in math { dim 8 -1 } } 9.000000
 		equal { do\in math { dim -4 -2 } } 0.000000
 	}
+
+	group "erf"
+	mold\nowrap "" 
+	{ { string } }
+	{
+		equal { do\in math { erf 1.5 } } 0.9661051464753108
+	}
+
+	group "erfc"
+	mold\nowrap "" 
+	{ { string } }
+	{
+		equal { do\in math { erfc 1.5 } } 0.033894853524689274
+	}
+
+	group "erfcinv"
+	mold\nowrap "" 
+	{ { string } }
+	{
+		equal { do\in math { erfcinv 1.5 } } -0.4769362762044699
+		equal { do\in math { erfcinv 0 } } +Inf
+		equal { do\in math { erfcinv 2 } } -Inf
+		equal { do\in math { erfcinv 2.2 } } NaN
+	}
+
+	group "erfinv"
+	mold\nowrap "" 
+	{ { string } }
+	{
+		equal { do\in math { erfcinv 0.5 } } 0.4769362762044699
+		equal { do\in math { erfcinv 1 } } +Inf
+		equal { do\in math { erfcinv -1 } } -Inf
+		equal { do\in math { erfcinv 1.5 } } NaN
+	}
 	
 }
 

--- a/tests/misc.rye
+++ b/tests/misc.rye
@@ -450,9 +450,9 @@ section "Math functions"
 	{ { string } }
 	{
 		equal { do\in math { erfcinv 1.5 } } -0.4769362762044699
-		equal { do\in math { erfcinv 0 } } +Inf
-		equal { do\in math { erfcinv 2 } } -Inf
-		equal { do\in math { erfcinv 2.2 } } NaN
+		equal { do\in math { erfcinv 0 } } "+Inf"
+		equal { do\in math { erfcinv 2 } } "-Inf"
+		equal { do\in math { erfcinv 2.2 } } "NaN"
 	}
 
 	group "erfinv"
@@ -460,9 +460,9 @@ section "Math functions"
 	{ { string } }
 	{
 		equal { do\in math { erfcinv 0.5 } } 0.4769362762044699
-		equal { do\in math { erfcinv 1 } } +Inf
-		equal { do\in math { erfcinv -1 } } -Inf
-		equal { do\in math { erfcinv 1.5 } } NaN
+		equal { do\in math { erfcinv 1 } } "+Inf"
+		equal { do\in math { erfcinv -1 } } "-Inf"
+		equal { do\in math { erfcinv 1.5 } } "NaN"
 	}
 	
 }


### PR DESCRIPTION
**Changes:**
1. Adding Erf, Erfc, Erfcinv and Erfinv math functions
2. Adding test cases of all Erf* math functions

**Testing:**
Test in Rye:
![image](https://github.com/refaktor/rye/assets/5825319/4f7db67b-e7f2-442f-860e-a8a9eaf863e7)
![image](https://github.com/refaktor/rye/assets/5825319/b58c36c7-661d-4904-b8c5-4aef3cebdaab)



Testcases check:
![image](https://github.com/refaktor/rye/assets/5825319/e6fad89c-7841-47bb-b252-8876e3408cc4)
![image](https://github.com/refaktor/rye/assets/5825319/b7e40095-632c-4ba2-9900-d492d9a82f36)

**Doubts:**
Do we need to add restriction for +Inf, -Inf and NaN  values in our custom functions? In Rye command line it is giving proper value so i have removed it. but in Testcases it is giving me like below. Is it the correct thing?
```
TYPES
  - Error: expected NaN, got NaN
```

But our test cases is not failed (FAILED: 0). It Passed if i compare with "NaN". 

- Code is working fine, So we can merge this PR.