### PR TITLE
[Add math functions] Adding  exp exp2 expm1 and fma math function

### DIFF
--- a/evaldo/builtins_math.go
+++ b/evaldo/builtins_math.go
@@ -496,6 +496,62 @@ var Builtins_math = map[string]*env.Builtin{
 			}
 		},
 	},
+	"fma": {
+		Argsn: 3,
+		Doc:   "Returns x * y + z, computed with only one rounding. (That is, FMA returns the fused multiply-add of x, y, and z.)",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch val1 := arg0.(type) {
+			case env.Integer:
+				switch val2 := arg1.(type) {
+				case env.Integer:
+					switch val3 := arg2.(type) {
+					case env.Integer:
+						return *env.NewDecimal(math.FMA(float64(val1.Value), float64(val2.Value), float64(val3.Value)))
+					case env.Decimal:
+						return *env.NewDecimal(math.FMA(float64(val1.Value), float64(val2.Value), val3.Value))
+					default:
+						return MakeArgError(ps, 3, []env.Type{env.IntegerType, env.DecimalType}, "fma")
+					}
+				case env.Decimal:
+					switch val3 := arg2.(type) {
+					case env.Integer:
+						return *env.NewDecimal(math.FMA(float64(val1.Value), val2.Value, float64(val3.Value)))
+					case env.Decimal:
+						return *env.NewDecimal(math.FMA(float64(val1.Value), val2.Value, val3.Value))
+					default:
+						return MakeArgError(ps, 3, []env.Type{env.IntegerType, env.DecimalType}, "fma")
+					}
+				default:
+					return MakeArgError(ps, 2, []env.Type{env.IntegerType, env.DecimalType}, "fma")
+				}
+			case env.Decimal:
+				switch val2 := arg1.(type) {
+				case env.Integer:
+					switch val3 := arg2.(type) {
+					case env.Integer:
+						return *env.NewDecimal(math.FMA(val1.Value, float64(val2.Value), float64(val3.Value)))
+					case env.Decimal:
+						return *env.NewDecimal(math.FMA(val1.Value, float64(val2.Value), val3.Value))
+					default:
+						return MakeArgError(ps, 3, []env.Type{env.IntegerType, env.DecimalType}, "fma")
+					}
+				case env.Decimal:
+					switch val3 := arg2.(type) {
+					case env.Integer:
+						return *env.NewDecimal(math.FMA(val1.Value, val2.Value, float64(val3.Value)))
+					case env.Decimal:
+						return *env.NewDecimal(math.FMA(val1.Value, val2.Value, val3.Value))
+					default:
+						return MakeArgError(ps, 3, []env.Type{env.IntegerType, env.DecimalType}, "fma")
+					}
+				default:
+					return MakeArgError(ps, 2, []env.Type{env.IntegerType, env.DecimalType}, "fma")
+				}
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.DecimalType}, "fma")
+			}
+		},
+	},
 	"pi": {
 		Argsn: 0,
 		Doc:   "Return Pi constant.",

--- a/evaldo/builtins_math.go
+++ b/evaldo/builtins_math.go
@@ -454,6 +454,48 @@ var Builtins_math = map[string]*env.Builtin{
 			}
 		},
 	},
+	"exp": {
+		Argsn: 1,
+		Doc:   "Returns e**x, the base-e exponential of x.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch val := arg0.(type) {
+			case env.Integer:
+				return *env.NewDecimal(math.Exp(float64(val.Value)))
+			case env.Decimal:
+				return *env.NewDecimal(math.Exp(val.Value))
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.DecimalType}, "exp")
+			}
+		},
+	},
+	"exp2": {
+		Argsn: 1,
+		Doc:   "Returns 2**x, the base-2 exponential of x.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch val := arg0.(type) {
+			case env.Integer:
+				return *env.NewDecimal(math.Exp2(float64(val.Value)))
+			case env.Decimal:
+				return *env.NewDecimal(math.Exp2(val.Value))
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.DecimalType}, "exp2")
+			}
+		},
+	},
+	"expm1": {
+		Argsn: 1,
+		Doc:   "Returns e**x - 1, the base-e exponential of x minus 1. It is more accurate than exp(x) - 1 when x is near zero.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch val := arg0.(type) {
+			case env.Integer:
+				return *env.NewDecimal(math.Expm1(float64(val.Value)))
+			case env.Decimal:
+				return *env.NewDecimal(math.Expm1(val.Value))
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.DecimalType}, "expm1")
+			}
+		},
+	},
 	"pi": {
 		Argsn: 0,
 		Doc:   "Return Pi constant.",

--- a/tests/misc.rye
+++ b/tests/misc.rye
@@ -481,7 +481,7 @@ section "Math functions"
 	mold\nowrap "" 
 	{ { string } }
 	{
-		equal { do\in math { expm1 2 } } 6.389056
+		equal { do\in math { expm1 2 } } 6.38905609893065
 	}
 	group "fma"
 	mold\nowrap "" 

--- a/tests/misc.rye
+++ b/tests/misc.rye
@@ -464,6 +464,31 @@ section "Math functions"
 		equal { do\in math { erfcinv -1 } } "-Inf"
 		equal { do\in math { erfcinv 1.5 } } "NaN"
 	}
+
+	group "exp"
+	mold\nowrap "" 
+	{ { string } }
+	{
+		equal { do\in math { exp 2 } } 7.38905609893065
+	}
+	group "exp2"
+	mold\nowrap "" 
+	{ { string } }
+	{
+		equal { do\in math { exp2 5 } } 32.000000
+	}
+	group "expm1"
+	mold\nowrap "" 
+	{ { string } }
+	{
+		equal { do\in math { expm1 2 } } 6.389056
+	}
+	group "fma"
+	mold\nowrap "" 
+	{ { string } }
+	{
+		equal { do\in math { fma 2.0 4.0 6.0 } } 14.00
+	}
 	
 }
 


### PR DESCRIPTION
**Changes:**
1. Adding support for `exp`, `exp2` and `expm1 `math function
2. Adding support for `FMA` math function
3. Adding test cases for all new math functions

**Testing:**
Rye command testing:
![image](https://github.com/refaktor/rye/assets/5825319/188d5dcb-6963-4200-9323-8610f77cff27)

Test cases verification:
![image](https://github.com/refaktor/rye/assets/5825319/82a4ccb4-16c5-428d-80ea-9496d47acbab)

