### PR TITLE
Improve microliner highlighter

### DIFF
--- a/wasm/ryeshell/index.html
+++ b/wasm/ryeshell/index.html
@@ -16,7 +16,7 @@
     <title>Rye evaluator - Rye Language</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">    
     <link rel="icon" href="https://ryelang.org/favicon.png">
-    <link rel="stylesheet" href="/css/style.css">
+    <!-- <link rel="stylesheet" href="/css/style.css"> -->
     <link rel="stylesheet" href="xterm.css" />
     <script src="xterm.js"></script>
     
@@ -229,7 +229,7 @@
   <body onload="onLoadX()" class='page page-default-single'><!doctype html>
     
     <h3 style="font-family: mono; font-weight: normal; font-size: 14px; color: #999; padding: 0px 10px;">Rye console (web)</h3>
-    <div id="terminal" style="width: 620px; padding: 10px; borde: 1px solid gray; background-color: #111; " ></div>
+    <div id="terminal" style="width: 620px; padding: 10px; border: 1px solid gray; background-color: #111; " ></div>
     <script>
       
       let theme = {


### PR DESCRIPTION
This PR refactors the microliner highlighter and can highlight more constructs.

The only issue with the current setup of highlighting one line at a time is with stings where opening a string in one line and continuing into multiline doesn't close it properly:

<img width="645" alt="Screenshot 2024-06-07 at 12 39 25" src="https://github.com/refaktor/rye/assets/9090706/4ae063b3-ea05-4cc8-8522-a26141f4b43a">

