### PR TITLE
Use Microliner in console

### DIFF
--- a/evaldo/builtins.go
+++ b/evaldo/builtins.go
@@ -2277,53 +2277,6 @@ var builtins = map[string]*env.Builtin{
 		},
 	},
 
-	"enter-console": {
-		Argsn: 1,
-		Doc:   "Stops execution and gives you a Rye console, to test the code inside environment.",
-		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
-			switch name := arg0.(type) {
-			case env.String:
-				ser := ps.Ser
-				/* ps.Ser = bloc.Series
-				EvalBlock(ps)
-				ps.Ser = ser */
-				//reader := bufio.NewReader(os.Stdin)
-
-				fmt.Println("Welcome to console: \033[1m" + name.Value + "\033[0m")
-				fmt.Println("* use \033[1mls\033[0m to list current context")
-				fmt.Println("-------------------------------------------------------------")
-				/*
-					for {
-						fmt.Print("{ rye dropin }")
-						text, _ := reader.ReadString('\n')
-						//fmt.Println(1111)
-						// convert CRLF to LF
-						text = strings.Replace(text, "\n", "", -1)
-						//fmt.Println(1111)
-						if strings.Compare("(lc)", text) == 0 {
-							fmt.Println(ps.Ctx.Print(*ps.Idx))
-						} else if strings.Compare("(r)", text) == 0 {
-							ps.Ser = ser
-							return ps.Res
-						} else {
-							// fmt.Println(1111)
-							block, genv := loader.LoadString("{ " + text + " }")
-							ps := env.AddToProgramState(ps, block.Series, genv)
-							EvalBlock(ps)
-							fmt.Println(ps.Res.Inspect(*ps.Idx))
-						}
-					}*/
-
-				DoRyeRepl(ps, "do", ShowResults)
-				fmt.Println("-------------------------------------------------------------")
-				ps.Ser = ser
-				return ps.Res
-			default:
-				return MakeArgError(ps, 1, []env.Type{env.StringType}, "enter-console")
-			}
-		},
-	},
-
 	/* TEMP FOR WASM 20250116
 	"get-input": {
 		Argsn: 1,
@@ -7831,6 +7784,7 @@ func RegisterBuiltins(ps *env.ProgramState) {
 	RegisterBuiltins2(Builtins_smtpd, ps, "smtpd")
 	RegisterBuiltins2(Builtins_mail, ps, "mail")
 	RegisterBuiltins2(Builtins_ssh, ps, "ssh")
+	RegisterBuiltins2(Builtins_console, ps, "console")
 	RegisterBuiltinsInContext(Builtins_math, ps, "math")
 	RegisterBuiltinsInContext(Builtins_devops, ps, "devops")
 	// ## Archived modules

--- a/evaldo/builtins_console.go
+++ b/evaldo/builtins_console.go
@@ -1,0 +1,58 @@
+//go:build !b_norepl && !wasm && !js
+
+package evaldo
+
+import (
+	"fmt"
+
+	"github.com/refaktor/rye/env"
+)
+
+var Builtins_console = map[string]*env.Builtin{
+	"enter-console": {
+		Argsn: 1,
+		Doc:   "Stops execution and gives you a Rye console, to test the code inside environment.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch name := arg0.(type) {
+			case env.String:
+				ser := ps.Ser
+				/* ps.Ser = bloc.Series
+				EvalBlock(ps)
+				ps.Ser = ser */
+				//reader := bufio.NewReader(os.Stdin)
+
+				fmt.Println("Welcome to console: \033[1m" + name.Value + "\033[0m")
+				fmt.Println("* use \033[1mls\033[0m to list current context")
+				fmt.Println("-------------------------------------------------------------")
+				/*
+					for {
+						fmt.Print("{ rye dropin }")
+						text, _ := reader.ReadString('\n')
+						//fmt.Println(1111)
+						// convert CRLF to LF
+						text = strings.Replace(text, "\n", "", -1)
+						//fmt.Println(1111)
+						if strings.Compare("(lc)", text) == 0 {
+							fmt.Println(ps.Ctx.Print(*ps.Idx))
+						} else if strings.Compare("(r)", text) == 0 {
+							ps.Ser = ser
+							return ps.Res
+						} else {
+							// fmt.Println(1111)
+							block, genv := loader.LoadString("{ " + text + " }")
+							ps := env.AddToProgramState(ps, block.Series, genv)
+							EvalBlock(ps)
+							fmt.Println(ps.Res.Inspect(*ps.Idx))
+						}
+					}*/
+
+				DoRyeRepl(ps, "do", ShowResults)
+				fmt.Println("-------------------------------------------------------------")
+				ps.Ser = ser
+				return ps.Res
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.StringType}, "enter-console")
+			}
+		},
+	},
+}

--- a/evaldo/builtins_console_not.go
+++ b/evaldo/builtins_console_not.go
@@ -1,0 +1,7 @@
+//go:build b_norepl || wasm || js
+
+package evaldo
+
+import "github.com/refaktor/rye/env"
+
+var Builtins_console = map[string]*env.Builtin{}

--- a/evaldo/evaldo.go
+++ b/evaldo/evaldo.go
@@ -982,6 +982,48 @@ func DirectlyCallBuiltin(ps *env.ProgramState, bi env.Builtin, a0 env.Object, a1
 	return bi.Fn(ps, arg0, arg1, arg2, arg3, arg4)
 }
 
+func MaybeDisplayFailureOrError(es *env.ProgramState, genv *env.Idxs) {
+	if es.FailureFlag {
+		fmt.Println("\x1b[33m" + "Failure" + "\x1b[0m")
+	}
+	if es.ErrorFlag {
+		fmt.Println("\x1b[31m" + es.Res.Print(*genv))
+		switch err := es.Res.(type) {
+		case env.Error:
+			fmt.Println(err.CodeBlock.PositionAndSurroundingElements(*genv))
+			fmt.Println("Error not pointer so bug. #temp")
+		case *env.Error:
+			fmt.Println("At location:")
+			fmt.Print(err.CodeBlock.PositionAndSurroundingElements(*genv))
+		}
+		fmt.Println("\x1b[0m")
+
+		// ENTER CONSOLE ON ERROR
+		// es.ErrorFlag = false
+		// es.FailureFlag = false
+		// DoRyeRepl(es, "do", true)
+	}
+	// cebelca2659- vklopi kontne skupine
+}
+
+func MaybeDisplayFailureOrErrorWASM(es *env.ProgramState, genv *env.Idxs, printfn func(string)) {
+	if es.FailureFlag {
+		printfn("\x1b[33m" + "Failure" + "\x1b[0m")
+	}
+	if es.ErrorFlag {
+		printfn("\x1b[31;3m" + es.Res.Print(*genv))
+		switch err := es.Res.(type) {
+		case env.Error:
+			printfn(err.CodeBlock.PositionAndSurroundingElements(*genv))
+			printfn("Error not pointer so bug. #temp")
+		case *env.Error:
+			printfn("At location:")
+			printfn(err.CodeBlock.PositionAndSurroundingElements(*genv))
+		}
+		printfn("\x1b[0m")
+	}
+}
+
 // if there is failure flag and given builtin doesn't accept failure
 // then error flag is raised and true returned
 // otherwise false

--- a/evaldo/repl.go
+++ b/evaldo/repl.go
@@ -1,4 +1,4 @@
-//go:build !b_norepl
+//go:build !b_norepl && !wasm && !js
 
 package evaldo
 
@@ -347,48 +347,6 @@ func DoRyeRepl(es *env.ProgramState, dialect string, showResults bool) { // here
 	_, err = ml.MicroPrompt("x> ", "", 0)
 	if err != nil {
 		fmt.Println(err)
-	}
-}
-
-func MaybeDisplayFailureOrError(es *env.ProgramState, genv *env.Idxs) {
-	if es.FailureFlag {
-		fmt.Println("\x1b[33m" + "Failure" + "\x1b[0m")
-	}
-	if es.ErrorFlag {
-		fmt.Println("\x1b[31m" + es.Res.Print(*genv))
-		switch err := es.Res.(type) {
-		case env.Error:
-			fmt.Println(err.CodeBlock.PositionAndSurroundingElements(*genv))
-			fmt.Println("Error not pointer so bug. #temp")
-		case *env.Error:
-			fmt.Println("At location:")
-			fmt.Print(err.CodeBlock.PositionAndSurroundingElements(*genv))
-		}
-		fmt.Println("\x1b[0m")
-
-		// ENTER CONSOLE ON ERROR
-		// es.ErrorFlag = false
-		// es.FailureFlag = false
-		// DoRyeRepl(es, "do", true)
-	}
-	// cebelca2659- vklopi kontne skupine
-}
-
-func MaybeDisplayFailureOrErrorWASM(es *env.ProgramState, genv *env.Idxs, printfn func(string)) {
-	if es.FailureFlag {
-		printfn("\x1b[33m" + "Failure" + "\x1b[0m")
-	}
-	if es.ErrorFlag {
-		printfn("\x1b[31;3m" + es.Res.Print(*genv))
-		switch err := es.Res.(type) {
-		case env.Error:
-			printfn(err.CodeBlock.PositionAndSurroundingElements(*genv))
-			printfn("Error not pointer so bug. #temp")
-		case *env.Error:
-			printfn("At location:")
-			printfn(err.CodeBlock.PositionAndSurroundingElements(*genv))
-		}
-		printfn("\x1b[0m")
 	}
 }
 

--- a/evaldo/repl.go
+++ b/evaldo/repl.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/eiannone/keyboard"
+
 	"github.com/refaktor/rye/env"
 	"github.com/refaktor/rye/loader"
 	"github.com/refaktor/rye/util"
@@ -301,7 +302,7 @@ func constructKeyEvent(r rune, k keyboard.Key) util.KeyEvent {
 	case keyboard.KeySpace:
 		ch = " "
 	}
-	return util.KeyEvent{ch, code, ctrl, alt, false}
+	return util.NewKeyEvent(ch, code, ctrl, alt, false)
 }
 
 func DoRyeRepl(es *env.ProgramState, dialect string, showResults bool) { // here because of some odd options we were experimentally adding

--- a/evaldo/repl.go
+++ b/evaldo/repl.go
@@ -3,6 +3,7 @@
 package evaldo
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -10,8 +11,10 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/eiannone/keyboard"
 	"github.com/refaktor/rye/env"
 	"github.com/refaktor/rye/loader"
+	"github.com/refaktor/rye/util"
 
 	"github.com/refaktor/liner"
 )
@@ -148,125 +151,201 @@ func MoveCursorBackward(bias int) {
 	fmt.Printf("\033[%dD", bias)
 }
 
-func DoRyeRepl(es *env.ProgramState, dialect string, showResults bool) { // here because of some odd options we were experimentally adding
-	//codestr := ""
-	//codelines := strings.Split(codestr, ",\n")
+type Repl struct {
+	ps *env.ProgramState
+	ml *util.MLState
 
-	line := liner.NewLiner()
-	defer line.Close()
+	dialect     string
+	showResults bool
 
-	line.SetCtrlCAborts(true)
+	fullCode string
 
-	line.SetCompleter(func(line string) (c []string) {
-		for i := 0; i < es.Idx.GetWordCount(); i++ {
-			if strings.HasPrefix(es.Idx.GetWord(i), strings.ToLower(line)) {
-				c = append(c, es.Idx.GetWord(i))
-			}
-		}
-		return
-	})
+	stack      *EyrStack
+	prevResult env.Object
+}
 
-	if f, err := os.Open(history_fn); err == nil {
-		if _, err := line.ReadHistory(f); err != nil {
-			log.Print("Error reading history file: ", err)
-		}
-		f.Close()
+func (r *Repl) recieveMessage(message string) {
+	fmt.Print(message)
+}
+
+func (r *Repl) recieveLine(line string) string {
+	res := r.evalLine(r.ps, line)
+	if r.showResults {
+		fmt.Print(res)
 	}
+	return res
+}
 
-	line2 := ""
-
-	var prevResult env.Object
-
-	stack := NewEyrStack()
-
-	for {
-		prompt, _ := genPrompt(nil, line2)
-
-		if code, err := line.Prompt(prompt); err == nil {
-			// strip comment
-
-			es.LiveObj.PsMutex.Lock()
-			for _, update := range es.LiveObj.Updates {
-				fmt.Println("\033[35m((Reloading " + update + "))\033[0m")
-				block_, script_ := LoadScriptLocalFile(es, *env.NewUri1(es.Idx, "file://"+update))
-				es.Res = EvaluateLoadedValue(es, block_, script_, true)
-			}
-			es.LiveObj.ClearUpdates()
-			es.LiveObj.PsMutex.Unlock()
-
-			multiline := len(code) > 1 && code[len(code)-1:] == " "
-
-			comment := regexp.MustCompile(`\s*;`)
-			line1 := comment.Split(code, 2) //--- just very temporary solution for some comments in repl. Later should probably be part of loader ... maybe?
-			lineReal := strings.Trim(line1[0], "\t")
-
-			if multiline {
-				line2 += lineReal + "\n"
-			} else {
-				line2 += lineReal
-
-				block, genv := loader.LoadString(line2, false)
-				block1 := block.(env.Block)
-				es = env.AddToProgramState(es, block1.Series, genv)
-
-				// EVAL THE DO DIALECT
-				if dialect == "do" {
-					EvalBlockInj(es, prevResult, true)
-				} else if dialect == "eyr" {
-					Eyr_EvalBlock(es, stack, true)
-				} else if dialect == "math" {
-					idxx, _ := es.Idx.GetIndex("math")
-					s1, ok := es.Ctx.Get(idxx)
-					if ok {
-						switch ss := s1.(type) {
-						case env.RyeCtx: /*  */
-							es.Ctx = &ss
-							// return s1
-						}
-					}
-					res := DialectMath(es, block1)
-					switch block := res.(type) {
-					case env.Block:
-						stack := NewEyrStack()
-						ser := es.Ser
-						es.Ser = block.Series
-						Eyr_EvalBlock(es, stack, false)
-						es.Ser = ser
-					}
-				}
-
-				MaybeDisplayFailureOrError(es, genv)
-
-				if !es.ErrorFlag && es.Res != nil {
-					prevResult = es.Res
-					if showResults {
-						fmt.Println("\033[38;5;37m" + es.Res.Inspect(*genv) + "\x1b[0m")
-					}
-				}
-
-				es.ReturnFlag = false
-				es.ErrorFlag = false
-				es.FailureFlag = false
-
-				line2 = ""
-			}
-
-			line.AppendHistory(code)
-		} else if err == liner.ErrPromptAborted {
-			break
-		} else {
-			log.Print("Error reading line: ", err)
-			break
-		}
+func (r *Repl) evalLine(es *env.ProgramState, code string) string {
+	es.LiveObj.PsMutex.Lock()
+	for _, update := range es.LiveObj.Updates {
+		fmt.Println("\033[35m((Reloading " + update + "))\033[0m")
+		block_, script_ := LoadScriptLocalFile(es, *env.NewUri1(es.Idx, "file://"+update))
+		es.Res = EvaluateLoadedValue(es, block_, script_, true)
 	}
+	es.LiveObj.ClearUpdates()
+	es.LiveObj.PsMutex.Unlock()
 
-	if f, err := os.Create(history_fn); err != nil {
-		log.Print("Error writing history file: ", err)
+	multiline := len(code) > 1 && code[len(code)-1:] == " "
+
+	comment := regexp.MustCompile(`\s*;`)
+	line := comment.Split(code, 2) //--- just very temporary solution for some comments in repl. Later should probably be part of loader ... maybe?
+	lineReal := strings.Trim(line[0], "\t")
+
+	output := ""
+	if multiline {
+		r.fullCode += lineReal + "\n"
 	} else {
-		if _, err := line.WriteHistory(f); err != nil {
-			log.Print("Error writing history file: ", err)
+		r.fullCode += lineReal
+
+		block, genv := loader.LoadString(r.fullCode, false)
+		block1 := block.(env.Block)
+		es = env.AddToProgramState(es, block1.Series, genv)
+
+		// EVAL THE DO DIALECT
+		if r.dialect == "do" {
+			EvalBlockInj(es, r.prevResult, true)
+		} else if r.dialect == "eyr" {
+			Eyr_EvalBlock(es, r.stack, true)
+		} else if r.dialect == "math" {
+			idxx, _ := es.Idx.GetIndex("math")
+			s1, ok := es.Ctx.Get(idxx)
+			if ok {
+				switch ss := s1.(type) {
+				case env.RyeCtx: /*  */
+					es.Ctx = &ss
+					// return s1
+				}
+			}
+			res := DialectMath(es, block1)
+			switch block := res.(type) {
+			case env.Block:
+				stack := NewEyrStack()
+				ser := es.Ser
+				es.Ser = block.Series
+				Eyr_EvalBlock(es, stack, false)
+				es.Ser = ser
+			}
 		}
-		f.Close()
+
+		MaybeDisplayFailureOrError(es, genv)
+
+		if !es.ErrorFlag && es.Res != nil {
+			r.prevResult = es.Res
+			output = fmt.Sprintf("\033[38;5;37m" + es.Res.Inspect(*genv) + "\x1b[0m")
+		}
+
+		es.ReturnFlag = false
+		es.ErrorFlag = false
+		es.FailureFlag = false
+
+		r.fullCode = ""
+	}
+
+	r.ml.AppendHistory(code)
+	return output
+}
+
+// constructKeyEvent maps a rune and keyboard.Key to a util.KeyEvent, which uses javascript key event codes
+// only keys used in microliner are mapped
+func constructKeyEvent(r rune, k keyboard.Key) util.KeyEvent {
+	var ctrl bool
+	alt := k == keyboard.KeyEsc
+	var code int
+	ch := string(r)
+	switch k {
+	case keyboard.KeyCtrlA:
+		ch = "a"
+		ctrl = true
+	case keyboard.KeyCtrlC:
+		ch = "c"
+		ctrl = true
+	case keyboard.KeyCtrlB:
+		ch = "b"
+		ctrl = true
+	case keyboard.KeyCtrlD:
+		ch = "d"
+		ctrl = true
+	case keyboard.KeyCtrlE:
+		ch = "e"
+		ctrl = true
+	case keyboard.KeyCtrlF:
+		ch = "f"
+		ctrl = true
+	case keyboard.KeyCtrlK:
+		ch = "k"
+		ctrl = true
+	case keyboard.KeyCtrlL:
+		ch = "l"
+		ctrl = true
+
+	case keyboard.KeyEnter:
+		code = 13
+	case keyboard.KeyBackspace, keyboard.KeyBackspace2:
+		code = 8
+	case keyboard.KeyDelete:
+		code = 46
+	case keyboard.KeyArrowRight:
+		code = 39
+	case keyboard.KeyArrowLeft:
+		code = 37
+	case keyboard.KeyArrowUp:
+		code = 38
+	case keyboard.KeyArrowDown:
+		code = 40
+	case keyboard.KeyHome:
+		code = 36
+	case keyboard.KeyEnd:
+		code = 35
+
+	case keyboard.KeySpace:
+		ch = " "
+	}
+	return util.KeyEvent{ch, code, ctrl, alt, false}
+}
+
+func DoRyeRepl(es *env.ProgramState, dialect string, showResults bool) { // here because of some odd options we were experimentally adding
+	err := keyboard.Open()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer keyboard.Close()
+
+	c := make(chan util.KeyEvent)
+	r := Repl{
+		ps:          es,
+		dialect:     dialect,
+		showResults: showResults,
+		stack:       NewEyrStack(),
+	}
+	ml := util.NewMicroLiner(c, r.recieveMessage, r.recieveLine)
+	r.ml = ml
+
+	ctx := context.Background()
+	defer ctx.Done()
+	go func(ctx context.Context) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				r, k, keyErr := keyboard.GetKey()
+				if err != nil {
+					fmt.Println(keyErr)
+					break
+				}
+				if k == keyboard.KeyCtrlC {
+					ctx.Done()
+				}
+				c <- constructKeyEvent(r, k)
+			}
+		}
+	}(ctx)
+
+	_, err = ml.MicroPrompt("x> ", "", 0)
+	if err != nil {
+		fmt.Println(err)
 	}
 }
 

--- a/evaldo/repl_not.go
+++ b/evaldo/repl_not.go
@@ -1,4 +1,4 @@
-//go:build b_norepl
+//go:build b_norepl && (wasm || js)
 
 package evaldo
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/blevesearch/bleve/v2 v2.4.0
 	github.com/blevesearch/bleve_index_api v1.1.8
 	github.com/drewlanenga/govector v0.0.0-20220726163947-b958ac08bc93
+	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gliderlabs/ssh v0.3.7
 	github.com/go-gomail/gomail v0.0.0-20160411212932-81ebce5c23df

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/drewlanenga/govector v0.0.0-20220726163947-b958ac08bc93 h1:2VXZHsypUG1HaQcj/+nQc5TbZ4qZ5FSl7KN4s1BjFQY=
 github.com/drewlanenga/govector v0.0.0-20220726163947-b958ac08bc93/go.mod h1:AbP/uRrjZFATEwl0P2DHePteIMZRWHEJBWBmMmLdCkk=
+github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203 h1:XBBHcIb256gUJtLmY22n99HaZTz+r2Z51xUPi01m3wg=
+github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203/go.mod h1:E1jcSv8FaEny+OP/5k9UxZVw9YFWGj7eI4KR/iOBqCg=
 github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx3GhA=
 github.com/frankban/quicktest v1.14.5/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=

--- a/main_wasm.go
+++ b/main_wasm.go
@@ -86,7 +86,7 @@ func main() {
 
 	js.Global().Set("SendKeypress", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		if len(args) > 0 {
-			cc := util.KeyEvent{args[0].String(), args[1].Int(), args[2].Bool(), args[3].Bool(), args[4].Bool()}
+			cc := util.NewKeyEvent(args[0].String(), args[1].Int(), args[2].Bool(), args[3].Bool(), args[4].Bool())
 			c <- cc
 		}
 		return nil

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1,3 +1,5 @@
+//go:build !wasm
+
 package runner
 
 import (

--- a/util/microliner.go
+++ b/util/microliner.go
@@ -443,6 +443,8 @@ startOfHere:
 		pLen := countGlyphs(p)
 		if next.Ctrl {
 			switch strings.ToLower(next.Key) {
+			case "c":
+				return "", nil
 			case "a":
 				pos = 0
 				// s.needRefresh = true
@@ -547,6 +549,7 @@ startOfHere:
 					line = append(line[:pos], line[pos+1:]...)
 					trace(buf)
 				}
+				s.needRefresh = true
 				// Save the result on the killRing
 				/*if killAction > 0 {
 					s.addToKillRing(buf, 2) // Add in prepend mode

--- a/util/microliner.go
+++ b/util/microliner.go
@@ -77,6 +77,10 @@ type KeyEvent struct {
 	Shift bool
 }
 
+func NewKeyEvent(key string, code int, ctrl bool, alt bool, shift bool) KeyEvent {
+	return KeyEvent{key, code, ctrl, alt, shift}
+}
+
 func (s *MLState) cursorPos(x int) {
 	// 'C' is "Cursor Forward (CUF)"
 	s.sendBack("\r")


### PR DESCRIPTION
This PR replaces the `refaktor/liner` with `Microliner` in the console repl so it's the same liner for both wasm and console.

When testing it out on MacOS I noticed two bugs:
1. CMD+backspace (should delete from cursor to start of the line) doesn't work and I couldn't figure out how to make it work.
2. Microliner doesn't behave well if the text overflows the console width (also an issue on wasm repl). This was handled in the old liner and should be fixed.

Otherwise everything that I've tested looks fine but we should also test on Linux and Windows before merging.