### PR TITLE
Enable build on windows in CI and on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
       timeout-minutes: 1
 
     - name: Build WASM
+      if: runner.os == 'Linux'
       run: |
         GOOS=js GOARCH=wasm go build -v -tags "b_tiny" -o wasm/rye.wasm main_wasm.go
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         image:
           - macos-latest
           - ubuntu-latest
-          # - windows-latest
+          - windows-latest
     runs-on: ${{ matrix.image }}
 
     steps:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,7 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      # - windows
+      - windows
       - darwin
       - js
     goarch:
@@ -28,10 +28,8 @@ builds:
       - wasm
     
     ignore: # List of combinations of GOOS + GOARCH + GOARM to ignore.
-      # - goos: windows
-      #   goarch: arm64
-      # - goos: windows
-      #   goarch: arm
+      - goos: windows
+        goarch: arm
 
     flags:
     - -tags=b_tiny

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/gobwas/ws v1.4.0
 	github.com/gorilla/sessions v1.2.2
 	github.com/jinzhu/copier v0.4.0
+	github.com/kopoli/go-terminal-size v0.0.0-20170219200355-5c97524c8b54
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/lib/pq v1.10.9
 	github.com/mattn/go-runewidth v0.0.15

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMWAQ=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/kopoli/go-terminal-size v0.0.0-20170219200355-5c97524c8b54 h1:0SMHxjkLKNawqUjjnMlCtEdj6uWZjv0+qDZ3F6GOADI=
+github.com/kopoli/go-terminal-size v0.0.0-20170219200355-5c97524c8b54/go.mod h1:bm7MVZZvHQBfqHG5X59jrRE/3ak6HvK+/Zb6aZhLR2s=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/util/getcolumns_native.go
+++ b/util/getcolumns_native.go
@@ -4,23 +4,15 @@
 package util
 
 import (
-	"syscall"
-	"unsafe"
+	tsize "github.com/kopoli/go-terminal-size"
 )
 
-type winSize struct {
-	row, col       uint16
-	xpixel, ypixel uint16
-}
-
 func GetTerminalColumns() int {
-	var ws winSize
-	// TODO -- MOVE THIS OUTSIDE ... in case of native use this, in case of browser check how we can get the numer of columns
-	ok, _, _ := syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdout),
-		syscall.TIOCGWINSZ, uintptr(unsafe.Pointer(&ws)))
-	if int(ok) < 0 {
-		return 50
+	var s tsize.Size
+
+	s, err := tsize.GetSize()
+	if err == nil {
+		return s.Width
 	}
-	columns := int(ws.col)
-	return columns
+	return 50
 }


### PR DESCRIPTION
Windows support was added by @xypwn in
* #239 
 
and then broken in
* #262

...which should be fixed in:
https://github.com/refaktor/rye/blob/bd61e7f2d951f953a42c4d566e3969d88ffa218b/util/getcolumns_native.go#L18-L23