### PR TITLE
Return Error Getting First Row Of Empty Spreadsheet

### DIFF
--- a/evaldo/builtins.go
+++ b/evaldo/builtins.go
@@ -6373,6 +6373,9 @@ var builtins = map[string]*env.Builtin{
 				}
 				return *env.NewString(string(str[0]))
 			case env.Spreadsheet:
+				if s1.NRows() == 0 {
+					return MakeBuiltinError(ps, "Spreadsheet is empty.", "first")
+				}
 				return s1.GetRow(ps, int(0))
 			default:
 				return MakeArgError(ps, 1, []env.Type{env.SpreadsheetType, env.BlockType, env.StringType, env.ListType}, "first")

--- a/tests/structures.rye
+++ b/tests/structures.rye
@@ -21,6 +21,7 @@ section "Working with blocks and lists"
 		equal { try { first { } } |type? } 'error
 		equal { try { first list { } } |type? } 'error
 		equal { try { first "" } |type? } 'error
+		equal { try { first spreadsheet { "Name" } [ ] } |type? } 'error
 	}
 
 	group "rest"


### PR DESCRIPTION
Update `first` to return an error on an empty spreadsheet.
Fixes panic in this scenario.
