### PR TITLE
Error When Using Invalid Column With add-col!

### DIFF
--- a/evaldo/builtins_spreadsheet.go
+++ b/evaldo/builtins_spreadsheet.go
@@ -845,7 +845,7 @@ func GenerateColumn(ps *env.ProgramState, s env.Spreadsheet, name env.Word, extr
 				}
 				// fmt.Println(val)
 				if er != nil {
-					return nil
+					return MakeBuiltinError(ps, er.Error(), "add-col!")
 				}
 				if firstVal == nil {
 					var ok bool

--- a/tests/structures.rye
+++ b/tests/structures.rye
@@ -611,6 +611,13 @@ section "Spreadsheet related functions"
 		equal { to-spreadsheet vals { dict { "a" 1 b 2 "c" 3 } dict { "a" 4 "b" 5 } } } spreadsheet { "a" "b" "c" } { 1 2 3 4 5 _ }
 	}
 
+	group "add-col"
+	mold\nowrap ?add-col!
+	{ { block } }
+	{
+		equal { try { spreadsheet { "n" } [ 1 ] |add-col! 'm { x } { x } } |type? } 'error
+	}
+
 	group "index"
 	mold\nowrap ?add-indexes!
 	{ { block } }


### PR DESCRIPTION
Return an error when `add-col!` is called with an invalid column.
