### PR TITLE
Error When Loading Empty CSV File

### DIFF
--- a/evaldo/builtins_spreadsheet.go
+++ b/evaldo/builtins_spreadsheet.go
@@ -225,6 +225,9 @@ var Builtins_spreadsheet = map[string]*env.Builtin{
 					// log.Fatal("Unable to parse file as CSV for "+filePath, err)
 					return MakeBuiltinError(ps, "Unable to parse file as CSV.", "load\\csv")
 				}
+				if len(rows) == 0 {
+					return MakeBuiltinError(ps, "File is empty", "load\\csv")
+				}
 				spr := env.NewSpreadsheet(rows[0])
 				//				for i, row := range rows {
 				//	if i > 0 {

--- a/tests/structures.rye
+++ b/tests/structures.rye
@@ -567,6 +567,12 @@ section "Serializers and loaders"
 		equal { load "1 2 { print 4 }" |third |first |type? } 'word
 	}
 
+	group "load\csv"
+	mold\nowrap ?load\csv
+	{ { block } }
+	{
+		equal { try { load\csv file:///dev/null } |type? } 'error
+	}
 
 }
 


### PR DESCRIPTION
Return an error when `load\csv` reads an empty file.  Fixes panic in
this scenario.
