### PR TITLE
Fix examples/adventofcode/2022/3

### DIFF
--- a/examples/adventofcode/2022/3/main.rye
+++ b/examples/adventofcode/2022/3/main.rye
@@ -11,25 +11,18 @@
     
     read\lines %rucksacks.txt :lines
     |fold 'priority 0 {
-    	.length? / 2 :mid ,
-    	.split-every mid |pass { .first :left } |second
-    	|intersect left |fold 'priority1 0 {
+	.length? / 2 |to-integer ::mid ,
+	.split\every mid |pass { .first ::left } |second
+	|intersection left |unique |fold 'priority1 0 {
             .get-priority + priority1
-    	} |+ priority
+	} |+ priority
     } |print
     
     ; part 2
 
-    lines .split-every 3 |fold 'priority 0 {
-    	-> 0 :line0 ,
-    	-> 1 :line1 ,
-    	-> 2 |intersect line1 |intersect line0
-    	|get-priority + priority
+    lines .split\every 3 |fold 'priority 0 {
+    	-> 0 ::line0 ,
+    	-> 1 ::line1 ,
+    	-> 2 |intersection line1 |intersection line0
+        |unique	|get-priority + priority
     } |print
-
-
-
-
-
-
-

--- a/examples/adventofcode/2022/3/main2.rye
+++ b/examples/adventofcode/2022/3/main2.rye
@@ -9,21 +9,21 @@
     
     ; part 1
     
-    read\lines %rucksacks.txt :lines |add-up {
-    	.length? / 2 :mid ,
-	    .split-every mid
-	    |with { .first :left , .second }
-    	|intersect left |add-up { .get-priority }
-    } |print
+    read\lines %rucksacks.txt :lines |map {
+    	.length? / 2 |to-integer ::mid ,
+	    .split\every mid
+	    |with { .first ::left , .second }
+    	|intersection left |unique .map { .get-priority } |sum
+    } |sum |print
     
     ; part 2
 
-    lines .split-every 3 |add-up {
-    	-> 0 :line0 ,
-    	-> 1 :line1 ,
-    	-> 2 |intersect line1 |intersect line0
-    	|get-priority
-    } |print
+    lines .split\every 3 |map {
+    	-> 0 ::line0 ,
+    	-> 1 ::line1 ,
+    	-> 2 |intersection line1 |intersection line0
+    	|unique .get-priority
+    } |sum |print
 
 
 


### PR DESCRIPTION
The code in examples/adventofcode/2022/3 did not run. With help from  refaktor on reddit (/u/middayc) I have fixed this.

The results agree with my successful Ruby code, written at the time for the Advent of Code.

- fix obsolete method names split-every, intersect
- use modwords where needed
- insert `|unique` calls where needed for problem semantics