### PR TITLE
Address #305: function names in error messages

### DIFF
--- a/evaldo/builtins.go
+++ b/evaldo/builtins.go
@@ -2387,11 +2387,11 @@ var builtins = map[string]*env.Builtin{
 					return ps.Res
 				default:
 					ps.ErrorFlag = true
-					return MakeArgError(ps, 2, []env.Type{env.BlockType}, "do-in")
+					return MakeArgError(ps, 2, []env.Type{env.BlockType}, "do\\in")
 				}
 			default:
 				ps.ErrorFlag = true
-				return MakeArgError(ps, 1, []env.Type{env.CtxType}, "do-in")
+				return MakeArgError(ps, 1, []env.Type{env.CtxType}, "do\\in")
 			}
 
 		},
@@ -2420,11 +2420,11 @@ var builtins = map[string]*env.Builtin{
 					return ps.Res
 				default:
 					ps.ErrorFlag = true
-					return MakeArgError(ps, 2, []env.Type{env.BlockType}, "do-in")
+					return MakeArgError(ps, 2, []env.Type{env.BlockType}, "do\\in\\try")
 				}
 			default:
 				ps.ErrorFlag = true
-				return MakeArgError(ps, 1, []env.Type{env.CtxType}, "do-in")
+				return MakeArgError(ps, 1, []env.Type{env.CtxType}, "do\\in\\try")
 			}
 
 		},
@@ -2471,11 +2471,11 @@ var builtins = map[string]*env.Builtin{
 					return ps.Res
 				default:
 					ps.ErrorFlag = true
-					return MakeArgError(ps, 2, []env.Type{env.BlockType}, "do-in")
+					return MakeArgError(ps, 2, []env.Type{env.BlockType}, "do\\par")
 				}
 			default:
 				ps.ErrorFlag = true
-				return MakeArgError(ps, 1, []env.Type{env.CtxType}, "do-in")
+				return MakeArgError(ps, 1, []env.Type{env.CtxType}, "do\\par")
 			}
 
 		},
@@ -5064,7 +5064,7 @@ var builtins = map[string]*env.Builtin{
 					return ps.Res
 				}
 			default:
-				return MakeArgError(ps, 1, []env.Type{env.IntegerType}, "recur-if\\1")
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType}, "recur-if")
 			}
 		},
 	},
@@ -6278,13 +6278,13 @@ var builtins = map[string]*env.Builtin{
 					case env.String:
 						return util.StringToFieldsWithQuoted(str.Value, sepa.Value, quote.Value)
 					default:
-						return MakeArgError(ps, 3, []env.Type{env.StringType}, "split-quoted")
+						return MakeArgError(ps, 3, []env.Type{env.StringType}, "split\\quoted")
 					}
 				default:
-					return MakeArgError(ps, 2, []env.Type{env.StringType}, "split-quoted")
+					return MakeArgError(ps, 2, []env.Type{env.StringType}, "split\\quoted")
 				}
 			default:
-				return MakeArgError(ps, 1, []env.Type{env.StringType}, "split-quoted")
+				return MakeArgError(ps, 1, []env.Type{env.StringType}, "split\\quoted")
 			}
 		},
 	},
@@ -6329,7 +6329,7 @@ var builtins = map[string]*env.Builtin{
 					}
 					return *env.NewBlock(*env.NewTSeries(spl2))
 				default:
-					return MakeArgError(ps, 2, []env.Type{env.IntegerType}, "split-every")
+					return MakeArgError(ps, 2, []env.Type{env.IntegerType}, "split\\every")
 				}
 			case env.Block:
 				switch sepa := arg1.(type) {
@@ -6341,10 +6341,10 @@ var builtins = map[string]*env.Builtin{
 					}
 					return *env.NewBlock(*env.NewTSeries(spl2))
 				default:
-					return MakeArgError(ps, 2, []env.Type{env.IntegerType}, "split-every")
+					return MakeArgError(ps, 2, []env.Type{env.IntegerType}, "split\\every")
 				}
 			default:
-				return MakeArgError(ps, 1, []env.Type{env.StringType, env.BlockType}, "split-every")
+				return MakeArgError(ps, 1, []env.Type{env.StringType, env.BlockType}, "split\\every")
 			}
 		},
 	},

--- a/evaldo/builtins_eyr.go
+++ b/evaldo/builtins_eyr.go
@@ -302,7 +302,7 @@ var Builtins_eyr = map[string]*env.Builtin{
 				CompileRyeToEyr(&bloc, ps, eBlock)
 				return *eBlock
 			default:
-				return MakeArgError(ps, 1, []env.Type{env.BlockType}, "eyr")
+				return MakeArgError(ps, 1, []env.Type{env.BlockType}, "to-eyr")
 			}
 		},
 	},
@@ -320,7 +320,7 @@ var Builtins_eyr = map[string]*env.Builtin{
 				ps.Ser = ser
 				return ps.Res
 			default:
-				return MakeArgError(ps, 1, []env.Type{env.BlockType}, "eyr")
+				return MakeArgError(ps, 1, []env.Type{env.BlockType}, "eyr\\full")
 			}
 		},
 	},
@@ -343,10 +343,10 @@ var Builtins_eyr = map[string]*env.Builtin{
 					ps.Ser = ser
 					return ps.Res
 				default:
-					return MakeArgError(ps, 2, []env.Type{env.BlockType}, "eyr-loop")
+					return MakeArgError(ps, 2, []env.Type{env.BlockType}, "eyr\\loop")
 				}
 			default:
-				return MakeArgError(ps, 1, []env.Type{env.IntegerType}, "eyr-loop")
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType}, "eyr\\loop")
 			}
 		},
 	},

--- a/evaldo/builtins_math.go
+++ b/evaldo/builtins_math.go
@@ -814,7 +814,7 @@ var Builtins_math = map[string]*env.Builtin{
 	},
 	"near-zero": {
 		Argsn: 1,
-		Doc:   "Returns true if two decimals are close.",
+		Doc:   "Returns true if a decimal is close to zero.",
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
 			var fa float64
 			switch a := arg0.(type) {
@@ -823,7 +823,7 @@ var Builtins_math = map[string]*env.Builtin{
 			case env.Integer:
 				fa = float64(a.Value)
 			default:
-				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.BlockType}, "is-zero")
+				return MakeArgError(ps, 1, []env.Type{env.IntegerType, env.BlockType}, "near-zero")
 			}
 			// const epsilon = math.SmallestNonzeroFloat64
 			const epsilon = 0.0000000000001 // math.SmallestNonzeroFloat64


### PR DESCRIPTION
Some functions are named incorrectly in their own error messages.

Examples:
- split\every appears as "split-every" in its own error messages
  - most of the cases I found have this form: backslash appears as hyphen
- to-eyr and eyr\full both appear as "eyr"
  - this appears to be a copy/paste issue; there are some other occurrences
- near-zero appears as "is-zero"
  - perhaps an artifact of a renaming
  - this function's descriptive string was also wrong

The commit contains the cases that I found. I don't have a systematic way to check all the error messages, so there are probably still some more cases.