### PR TITLE
[pipes-functions]Adding sha256sum and sums functions

### DIFF
--- a/evaldo/builtins_pipes.go
+++ b/evaldo/builtins_pipes.go
@@ -634,6 +634,47 @@ var Builtins_pipes = map[string]*env.Builtin{
 		},
 	},
 
+	"sha256sum": {
+		Argsn: 1,
+		Doc:   "Returns the hex-encoded SHA-256 hash of the entire contents of the pipe.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch p := arg0.(type) {
+			case env.Native:
+				switch pipe := p.Value.(type) {
+				case *script.Pipe:
+					sha256, err := pipe.SHA256Sum()
+					if err != nil {
+						return MakeBuiltinError(ps, err.Error(), "pipes/sha256sum")
+					}
+					return *env.NewString(sha256)
+				default:
+					return MakeNativeArgError(ps, 1, []string{"script-pipe"}, "pipes/sha256sum")
+				}
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.NativeType}, "pipes/sha256sum")
+			}
+		},
+	},
+
+	"sha256sums": {
+		Argsn: 1,
+		Doc:   "Reads paths from the pipe, one per line, and produces the hex-encoded SHA-256 hash of each corresponding file, one per line.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch p := arg0.(type) {
+			case env.Native:
+				switch pipe := p.Value.(type) {
+				case *script.Pipe:
+					newPipe := pipe.SHA256Sums()
+					return *env.NewNative(ps.Idx, newPipe, "script-pipe")
+				default:
+					return MakeNativeArgError(ps, 1, []string{"script-pipe"}, "pipes/sha256sums")
+				}
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.NativeType}, "pipes/sha256sums")
+			}
+		},
+	},
+
 	// GOPSUTIL
 
 }


### PR DESCRIPTION
**Changes:**
1. Adding `sha256sum `function
2. Adding `sha256sums `function

**Testing:**
![image](https://github.com/user-attachments/assets/f7a8353f-4953-402c-8ac8-54e3220d5a0b)

sha256sums function - for verification, i created a local test.txt file and checked.

**Doubt:**
1. Do we require to use every time` pipes/echo` ? If i try to use `rye .needs { pipes }`  and then directly `echo "hello"` then it is not working. Is it correct? or some other way we have to use?
![image](https://github.com/user-attachments/assets/76750f73-9c0f-4455-ba8e-f145623a3eae)

2. For all `builtins_pipes.go` functions, we do not have any unit test cases. Can you suggest me at which place we can add testcase for pipes, if needed? So from next PR i will add unit test cases.