### PR TITLE
[pipes-functions] Adding get and post function

### DIFF
--- a/evaldo/builtins_pipes.go
+++ b/evaldo/builtins_pipes.go
@@ -800,6 +800,31 @@ var Builtins_pipes = map[string]*env.Builtin{
 			}
 		},
 	},
+
+	"get": {
+		Argsn: 2,
+		Doc:   "Get makes an HTTP GET request to url, sending the contents of the pipe as the request body, and produces the server's response.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch p := arg0.(type) {
+			case env.Native:
+				switch pipe := p.Value.(type) {
+				case *script.Pipe:
+					switch s := arg1.(type) {
+					case env.String:
+						newPipe := pipe.Get(s.Value)
+						return *env.NewNative(ps.Idx, newPipe, "script-pipe")
+					default:
+						return MakeArgError(ps, 2, []env.Type{env.StringType}, "p-get")
+					}
+				default:
+					return MakeNativeArgError(ps, 1, []string{"script-pipe"}, "p-get")
+				}
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.NativeType}, "p-get")
+			}
+		},
+	},
+
 	// GOPSUTIL
 
 }

--- a/evaldo/builtins_pipes.go
+++ b/evaldo/builtins_pipes.go
@@ -791,7 +791,7 @@ var Builtins_pipes = map[string]*env.Builtin{
 					if closeErr != nil {
 						return *env.NewError("Error closing pipe")
 					}
-					return nil
+					return *env.NewInteger(0)
 				default:
 					return MakeNativeArgError(ps, 1, []string{"script-pipe"}, "p-close")
 				}

--- a/evaldo/builtins_pipes.go
+++ b/evaldo/builtins_pipes.go
@@ -825,6 +825,30 @@ var Builtins_pipes = map[string]*env.Builtin{
 		},
 	},
 
+	"post": {
+		Argsn: 2,
+		Doc:   "Post makes an HTTP POST request to url, using the contents of the pipe as the request body, and produces the server's response.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch p := arg0.(type) {
+			case env.Native:
+				switch pipe := p.Value.(type) {
+				case *script.Pipe:
+					switch s := arg1.(type) {
+					case env.String:
+						newPipe := pipe.Post(s.Value)
+						return *env.NewNative(ps.Idx, newPipe, "script-pipe")
+					default:
+						return MakeArgError(ps, 2, []env.Type{env.StringType}, "p-post")
+					}
+				default:
+					return MakeNativeArgError(ps, 1, []string{"script-pipe"}, "p-post")
+				}
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.NativeType}, "p-post")
+			}
+		},
+	},
+
 	// GOPSUTIL
 
 }


### PR DESCRIPTION
**Changes:**
1. Adding `get` function
2. Adding `post` function
3. For Close Pipe - if pass - return 0, previously it was nil. (previous [PR ](https://github.com/refaktor/rye/pull/351)change)

**Test:**
`get `function  - I have created a local server for testing and then passed `127.0.0.1:8080` URL
![image](https://github.com/user-attachments/assets/db853cd7-2819-4a64-a8ac-2fadf31daeca)
check by curl
![image](https://github.com/user-attachments/assets/2405d6a5-4761-44e3-adab-255cb1b612db)

`post `function -
![image](https://github.com/user-attachments/assets/9e9c2e2a-edee-4a75-bad4-fb919de8a766)
check by curl
![image](https://github.com/user-attachments/assets/f7e6a895-ccc0-48ef-b8b3-d9c38a777376)

close - return 0 (previous [PR ](https://github.com/refaktor/rye/pull/351)change )
![image](https://github.com/user-attachments/assets/136b83dc-5af4-4401-a920-1b0fd708dcc6)

tested - args: It is a printing passed argument. ( previous [PR](https://github.com/refaktor/rye/pull/351) change )
![image](https://github.com/user-attachments/assets/af442669-2e41-4a12-87d9-a5ae6413e679)

Related previous [PR ](https://github.com/refaktor/rye/pull/351)comment. I tried `cc pipes` instead of `do\par pipes` . It is giving block output. May be this thing you were saying or may be i missed something in understanding.
![image](https://github.com/user-attachments/assets/bee02370-95d3-4a1b-8dd1-a61455b0939b)
