### PR TITLE
Implement spreadsheet\rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ console_*.rye.enc
 buildtemp/main.rye
 *.bson
 cmd/parse_builtins/parse_builtinscmd/rbit/rbit
+
+cmd/rbit/rbit

--- a/evaldo/builtins.go
+++ b/evaldo/builtins.go
@@ -8118,7 +8118,7 @@ var builtins = map[string]*env.Builtin{
 	// Tests:
 	// equal { { } .is-empty } 1
 	// equal { dict { } |is-empty } 1
-	// equal { spreadsheet { } { } |is-empty } 1
+	// equal { spreadsheet { 'a 'b } { } |is-empty } 1
 	"is-empty": { // **
 		Argsn: 1,
 		Doc:   "Accepts a collection (String, Block, Dict, Spreadsheet) and returns it's length.", // TODO -- accept context

--- a/evaldo/builtins_spreadsheet.go
+++ b/evaldo/builtins_spreadsheet.go
@@ -20,6 +20,7 @@ var Builtins_spreadsheet = map[string]*env.Builtin{
 
 	// Tests:
 	//  equal { spreadsheet { "a" } { 1 2 } |type? } 'spreadsheet
+	//  equal { spreadsheet { 'a } { 1 2 } |type? } 'spreadsheet
 	// Args:
 	//  * columns
 	//  * data
@@ -86,7 +87,7 @@ var Builtins_spreadsheet = map[string]*env.Builtin{
 	},
 	// Tests:
 	//  equal { spreadsheet\rows { 'a 'b } { { 1 2 } { 3 4 } } } spreadsheet { 'a 'b } { 1 2 3 4 }
-	//  equal { spreadsheet\rows { 'a 'b } vals { list { 1 2 } list { 3 4 } } |type? } 'spreadsheet
+	//  equal { spreadsheet\rows { 'a 'b } list [ list [ 1 2 ] list [ 3 4 ] ] |type? } 'spreadsheet
 	// Args:
 	//  * columns - names of the columns
 	//  * data - block or list of rows (each row is a block or list)

--- a/info/base.info.rye
+++ b/info/base.info.rye
@@ -564,7 +564,7 @@ section "base" "base text" {
 	{
 		equal { { } .is-empty } 1
 		equal { dict { } |is-empty } 1
-		equal { spreadsheet { } { } |is-empty } 1
+		equal { spreadsheet { 'a 'b } { } |is-empty } 1
 	}
 
 	group "length?" 

--- a/info/spreadsheet.info.rye
+++ b/info/spreadsheet.info.rye
@@ -9,6 +9,7 @@ section "base" "base text" {
 
 	{
 		equal { spreadsheet { "a" } { 1 2 } |type? } 'spreadsheet
+		equal { spreadsheet { 'a } { 1 2 } |type? } 'spreadsheet
 	}
 
 	group "spreadsheet\\rows" 
@@ -20,7 +21,7 @@ section "base" "base text" {
 
 	{
 		equal { spreadsheet\rows { 'a 'b } { { 1 2 } { 3 4 } } } spreadsheet { 'a 'b } { 1 2 3 4 }
-		equal { spreadsheet\rows { 'a 'b } vals { list { 1 2 } list { 3 4 } } |type? } 'spreadsheet
+		equal { spreadsheet\rows { 'a 'b } list [ list [ 1 2 ] list [ 3 4 ] ] |type? } 'spreadsheet
 	}
 
 	group "to-spreadsheet" 

--- a/info/spreadsheet.info.rye
+++ b/info/spreadsheet.info.rye
@@ -11,6 +11,18 @@ section "base" "base text" {
 		equal { spreadsheet { "a" } { 1 2 } |type? } 'spreadsheet
 	}
 
+	group "spreadsheet\\rows" 
+	""
+	{
+		arg "* columns - names of the columns"
+		arg "* data - block or list of rows (each row is a block or list)"
+	}
+
+	{
+		equal { spreadsheet\rows { 'a 'b } { { 1 2 } { 3 4 } } } spreadsheet { 'a 'b } { 1 2 3 4 }
+		equal { spreadsheet\rows { 'a 'b } vals { list { 1 2 } list { 3 4 } } |type? } 'spreadsheet
+	}
+
 	group "to-spreadsheet" 
 	""
 	{
@@ -24,7 +36,7 @@ section "base" "base text" {
 	group "add-rows" 
 	""
 	{
-		arg "* sheet -the sheet that is getting rows added to it"
+		arg "* sheet - the sheet that is getting rows added to it"
 		arg "* rows - a block containing one or more rows worth of values, or a SpreadsheetRow Native value"
 	}
 


### PR DESCRIPTION
This PR implements the `spreadsheet\rows` builtin to construct a spreadsheet from a block or list or rows.

It also includes a few typo and linter fixes.