### PR TITLE
Update deprecated goreleaser config options

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,7 +46,7 @@ builds:
 
 
 archives:
-  - format: tar.gz
+  - formats: [ 'tar.gz' ]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -58,10 +58,11 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ 'zip' ]
 
 kos:  # See https://goreleaser.com/customization/ko/
-  - repository: ghcr.io/refaktor/rye
+  - repositories:
+    - ghcr.io/refaktor/rye
     tags:
     - '{{.Version}}'
     - latest
@@ -72,7 +73,7 @@ kos:  # See https://goreleaser.com/customization/ko/
     - linux/arm64
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog: # See https://goreleaser.com/customization/changelog/
   use: github
   sort: asc


### PR DESCRIPTION
Warnings (also in last release run: https://github.com/refaktor/rye/actions/runs/13692821787/job/38288967607#step:4:24):
* DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
* DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
* DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
* DEPRECATED:  kos.repository  should not be used anymore, check https://goreleaser.com/deprecations#kosrepository for more info