### PR TITLE
workflows: always use current stable Go

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: 'stable'
 
     - name: Install Linux cgo dependancies
       if: runner.os == 'Linux'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: 'stable'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: 'stable'
 
       - name: Run GoReleaser
         id: goreleaser


### PR DESCRIPTION
See https://github.com/actions/setup-go/tree/v5/#using-stableoldstable-aliases

Current `stable` is 1.24, `oldstable` is 1.23
Go 1.21 is not supported anymore.

We can use Go version from `go.mod` file to have it defined only in one place, but only once `setup-go` supports the `toolchain` directive:
* https://github.com/actions/setup-go/issues/457