### PR TITLE
Fix CallFunctionArgsN result

### DIFF
--- a/evaldo/evaldo.go
+++ b/evaldo/evaldo.go
@@ -901,6 +901,8 @@ func CallFunctionArgsN(fn env.Function, ps *env.ProgramState, ctx *env.RyeCtx, a
 	if psX.ForcedResult != nil {
 		ps.Res = ps.ForcedResult
 		ps.ForcedResult = nil
+	} else {
+		ps.Res = psX.Res
 	}
 	ps.ReturnFlag = false
 }


### PR DESCRIPTION
I ps.Res wasn't getting set, which means callback functions in Rye for Ryegen bindings didn't work.

This seems to fix the behavior based on my very limited testing, but I don't understand the Rye codebase deeply enough to know if this change may have some undesired implications.