### PR TITLE
Add parse-json\lines, fix round-trip with lists and dicts

### DIFF
--- a/evaldo/builtins_json.go
+++ b/evaldo/builtins_json.go
@@ -63,10 +63,14 @@ func RyeToJSON(res any) string {
 		return strconv.FormatFloat(v.Value, 'f', -1, 64)
 	case env.List:
 		return ListToJSON(v)
+	case []any:
+		return ListToJSON(*env.NewList(v))
 	case env.Vector:
 		return VectorToJSON(v)
 	case env.Dict:
 		return DictToJSON(v)
+	case map[string]any:
+		return DictToJSON(*env.NewDict(v))
 	case *env.Table:
 		return TableToJSON(*v)
 	case env.Table:


### PR DESCRIPTION
Hi!

I wanted to try rye's tables after your recent blog post, but found that a function to parse a table from JSON lines is missing so far, so I added one.

I called it `parse-json\lines` for symmetry with the existing `to-json\lines`, but it doesn't actually enforce lines and accepts any sequence of JSON values. Maybe something like `parse-json\sequence` would be more accurate.

I tried adding a test as well, but I couldn't figure out how to run these tests. The command from the README just prints an error (also without my modifications):

```
)> ../bin/rye main.rye test json
[Boolean: false]

# JSON #

Failure
Error: Wrong error constructor
At location::
  ... menu: base table formats io crypto  print-help: does print # Rye's simple testing tool

 use test or doc command

Examples:
 rye . test           # runs all tests
 rye . doc            # generates the docs out of tests
 rye . test ls        # lists the test sections available
 rye . test basics    # runs a specific test section
  first args |^fix print-help  |switch (here) test var 'sections  either args .length? ._> 1 either probe second args  ._= 'ls  print Test sections available: menu .for .concat  *  |print   sections:: second args    sections:: menu  if sections .length? ._> 0 var 'errors 0 for sections .to-string .pass term , prns
# , .to-upper .prns , print #
  |_| ._++ .info.rye |to-file |load |^check Group does not exist!!!!  |do\in test-framework |_+ errors |fix errors  ::errors  print  term term print TOTAL FAILED TESTS:  ._++ errors print  term print  either errors ._> 0 exit 1  exit 0    doc for menu .generate-doc-file menu  print docs generated  _ print-help   |probe
```

The test might also be wrong, but I don't understand why. Displaying the table from JSON gives a table with extra whitespace, whereas the table constructor gives one without whitespace:

```
x>  `{"a": 2, "b": "x"} \n{"a": 3, "b": "y"} \n` |parse-json\lines |to-table |display
| a     | b   |
+-------------+
| 2     | x   |
| 3     | y   |

x> table { "a" "b" } { 2 "x" 3 "y" } |display
| a | b |
+-------+
| 2 | x |
| 3 | y |
```

While testing these functions, I also noticed that dicts and lists don't round-trip through to-json, so I added the missing cases for that.

```
x> `[{"a": [1, 2]}]` |parse-json |to-json
[String: ["type map[string]interface {} not handeled"] ]
```