### PR TITLE
Add sh builtin for running external commands

### DIFF
--- a/evaldo/builtins.go
+++ b/evaldo/builtins.go
@@ -2416,6 +2416,7 @@ func RegisterBuiltins(ps *env.ProgramState) {
 	RegisterBuiltins2(Builtins_table, ps, "table")
 	RegisterBuiltins2(Builtins_vector, ps, "vector")
 	RegisterBuiltins2(Builtins_io, ps, "io")
+	RegisterBuiltins2(Builtins_cmd, ps, "cmd")
 	RegisterBuiltins2(Builtins_regexp, ps, "regexp")
 	RegisterBuiltins2(Builtins_validation, ps, "validation")
 	RegisterBuiltins2(Builtins_conversion, ps, "conversion")

--- a/evaldo/builtins_cmd.go
+++ b/evaldo/builtins_cmd.go
@@ -1,0 +1,459 @@
+package evaldo
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/refaktor/rye/env"
+)
+
+type command struct {
+	cmd *exec.Cmd
+	// pipe holds any commands that pipe into cmd.
+	pipe []*exec.Cmd
+	// files holds files that must be closed after the command finishes.
+	files []*os.File
+}
+
+func (c *command) StartPipe() error {
+	var err error
+	var stdout io.ReadCloser
+	for i, cmd := range c.pipe {
+		if i > 0 {
+			cmd.Stdin = stdout
+		}
+		stdout, err = cmd.StdoutPipe()
+		if err != nil {
+			return err
+		}
+		err = cmd.Start()
+		if err != nil {
+			return err
+		}
+	}
+	if stdout != nil {
+		c.cmd.Stdin = stdout
+	}
+	return nil
+}
+
+func (c *command) Close() error {
+	var errs []error
+	for _, cmd := range c.pipe {
+		err := cmd.Wait()
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	for _, f := range c.files {
+		err := f.Close()
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func listToCmdArgs(ps *env.ProgramState, input ...any) ([]string, *env.Error) {
+	var args []string
+	for _, c := range input {
+		switch it := c.(type) {
+		case string:
+			args = append(args, it)
+		case env.String:
+			args = append(args, it.Value)
+		case int:
+			args = append(args, strconv.Itoa(it))
+		case env.Integer:
+			args = append(args, strconv.Itoa(int(it.Value)))
+		case env.List:
+			newArgs, err := listToCmdArgs(ps, it.Data...)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, newArgs...)
+		case env.Flagword:
+			if it.HasLong() && it.HasShort() {
+				return nil, MakeBuiltinError(ps, fmt.Sprintf("ambiguous flagword %s", it.Print(*ps.Idx)), "cmd")
+			}
+			args = append(args, it.Print(*ps.Idx))
+		case env.Uri:
+			if it.GetProtocol().Print(*ps.Idx) == "file" {
+				args = append(args, it.GetPath())
+			} else {
+				args = append(args, it.GetFullUri(*ps.Idx))
+			}
+		default:
+			return nil, MakeBuiltinError(ps, fmt.Sprintf("Command argument must be string, integer, flagword, URI, or list, got %T", c), "cmd")
+		}
+	}
+	return args, nil
+}
+
+// pipeCommands creates a new command c1 | c2.
+func pipeCommands(c1, c2 *command) *command {
+	c1.cmd.Stdout = nil
+	p := command{cmd: c2.cmd}
+	p.pipe = append(p.pipe, c1.pipe...)
+	p.pipe = append(p.pipe, c1.cmd)
+	p.pipe = append(p.pipe, c2.pipe...)
+	p.files = append(p.files, c1.files...)
+	p.files = append(p.files, c2.files...)
+	return &p
+}
+
+// commandOutputFd resolves a Rye argument to a command output file for stdout or stderr.
+func commandOutputFd(ps *env.ProgramState, c *command, arg1 env.Object) (io.Writer, env.Object) {
+	switch s := arg1.(type) {
+	case env.Uri:
+		file, err := os.Create(s.Path)
+		if err != nil {
+			return nil, MakeBuiltinError(ps, err.Error(), "Stdout!")
+		}
+		c.files = append(c.files, file)
+		return file, nil
+	case env.Native:
+		switch it := s.Value.(type) {
+		case *os.File:
+			c.files = append(c.files, it)
+			return it, nil
+		case io.Writer:
+			return it, nil
+		}
+		return nil, MakeBuiltinError(ps, "arg1 must be of kind file or writer", "Stdout!")
+	default:
+		return nil, MakeArgError(ps, 2, []env.Type{env.UriType, env.NativeType}, "Stdout!")
+	}
+}
+
+// commandInputFd resolves a Rye argument to a command input file for stdin.
+func commandInputFd(ps *env.ProgramState, c *command, arg1 env.Object) (io.Reader, env.Object) {
+	switch s := arg1.(type) {
+	case env.Uri:
+		file, err := os.Open(s.Path)
+		if err != nil {
+			return nil, MakeBuiltinError(ps, err.Error(), "Stdin!")
+		}
+		c.files = append(c.files, file)
+		return file, nil
+	case env.Native:
+		switch it := s.Value.(type) {
+		case *os.File:
+			c.files = append(c.files, it)
+			return it, nil
+		case io.Reader:
+			return it, nil
+		}
+		return nil, MakeBuiltinError(ps, "arg1 must be of kind file or reader", "Stdin!")
+	default:
+		return nil, MakeArgError(ps, 2, []env.Type{env.UriType, env.NativeType}, "Stdin!")
+	}
+}
+
+func commandFn(name string, fn func(ps *env.ProgramState, c *command, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object) func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+	return func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+		switch r := arg0.(type) {
+		case env.Native:
+			c := r.Value.(*command)
+			return fn(ps, c, arg0, arg1, arg2, arg3, arg4)
+		default:
+			return MakeArgError(ps, 1, []env.Type{env.NativeType}, name)
+		}
+	}
+}
+
+var Builtins_cmd = map[string]*env.Builtin{
+	//
+	// ##### Command Operations #####  "Running other programs"
+	//
+	// Tests:
+	// equal { cmd { echo -n Hello World } |Output } "Hello World"
+	// equal { cmd { echo -n Hello World |tr A-Z a-z |sed "s/hello/goodbye/" } |Output } "goodbye world"
+	// equal { cmd { echo -n "1 + 1 =" { 1 + 1 } } |Output } "1 + 1 = 2"
+	// equal { args: list { "two" "arguments" } cmd { printf "'%s' " ?args } |Output } "'two' 'arguments' "
+	// Args:
+	// * command: block or list containing a command arguments
+	// Returns:
+	// * native command object
+	"cmd": {
+		Argsn: 1,
+		Doc:   "Create a command.",
+		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			var args []string
+			var pipe []*exec.Cmd
+			switch input := arg0.(type) {
+			case env.List:
+				newArgs, err := listToCmdArgs(ps, input.Data...)
+				if err != nil {
+					return err
+				}
+				args = append(args, newArgs...)
+			case env.Block:
+				for _, c := range input.Series.S {
+					switch it := c.(type) {
+					case env.Word:
+						args = append(args, it.Print(*ps.Idx))
+					case env.Pipeword:
+						word := it.ToWord().Print(*ps.Idx)
+						if len(args) == 0 {
+							return MakeBuiltinError(ps, "missing command before pipe", "cmd")
+						}
+						pipecmd := exec.Command(args[0], args[1:]...)
+						pipecmd.Stdin = os.Stdin
+						pipecmd.Stderr = os.Stderr
+						pipe = append(pipe, pipecmd)
+						args = []string{word}
+					case env.Getword:
+						EvalGetword(ps, it, nil, false)
+						if ps.ErrorFlag {
+							return ps.Res
+						}
+						newArgs, err := listToCmdArgs(ps, ps.Res)
+						if err != nil {
+							return err
+						}
+						args = append(args, newArgs...)
+					case env.Block:
+						ser := ps.Ser
+						ps.Ser = it.Series
+						ps.BlockFile = it.FileName
+						ps.BlockLine = it.Line
+						EvalBlock(ps)
+						if ps.ErrorFlag {
+							return ps.Res
+						}
+						ps.Ser = ser
+						newArgs, err := listToCmdArgs(ps, ps.Res)
+						if err != nil {
+							// TODO: Better message
+							return err
+						}
+						args = append(args, newArgs...)
+					default:
+						newArgs, err := listToCmdArgs(ps, it)
+						if err != nil {
+							// TODO: Better message
+							return err
+						}
+						args = append(args, newArgs...)
+					}
+				}
+			default:
+				return MakeArgError(ps, 1, []env.Type{env.BlockType, env.ListType}, "cmd")
+			}
+
+			if len(args) == 0 {
+				return MakeBuiltinError(ps, "missing command", "cmd")
+			}
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Stdin = os.Stdin
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			return *env.NewNative(ps.Idx, &command{cmd: cmd, pipe: pipe}, "command")
+		},
+	},
+	// Tests:
+	// equal { cmd { pwd } |Dir! %/ |Output |trim } "/"
+	// Args:
+	// * command: native command object
+	// * dir: path to the working directory
+	// Returns:
+	// * the original command object
+	"command//Dir!": {
+		Argsn: 2,
+		Doc:   "Change the working directory of a command.",
+		Fn: commandFn("Dir!", func(ps *env.ProgramState, c *command, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch s := arg1.(type) {
+			case env.Uri:
+				c.cmd.Dir = s.Path
+				return arg0
+			default:
+				return MakeArgError(ps, 2, []env.Type{env.UriType}, "Dir!")
+			}
+		}),
+	},
+	// Args:
+	// * command: native command object
+	// * input: path to an input file, a native file object, or a reader
+	// Returns:
+	// * the original command object
+	"command//Stdin!": {
+		Argsn: 2,
+		Doc:   "Change the standard input of a command.",
+		Fn: commandFn("Stdin!", func(ps *env.ProgramState, c *command, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			out, ret := commandInputFd(ps, c, arg1)
+			if ret != nil {
+				return ret
+			}
+			c.cmd.Stdin = out
+			return arg0
+		}),
+	},
+	// Args:
+	// * command: native command object
+	// * output: path to an output file, a native file object, or a writer
+	// Returns:
+	// * the original command object
+	"command//Stdout!": {
+		Argsn: 2,
+		Doc:   "Change the standard output of a command.",
+		Fn: commandFn("Stdout!", func(ps *env.ProgramState, c *command, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			out, ret := commandOutputFd(ps, c, arg1)
+			if ret != nil {
+				return ret
+			}
+			c.cmd.Stdout = out
+			return arg0
+		}),
+	},
+	// Args:
+	// * command: native command object
+	// * output: path to an output file, a native file object, or a writer
+	// Returns:
+	// * the original command object
+	"command//Stderr!": {
+		Argsn: 2,
+		Doc:   "Change the standard error of a command.",
+		Fn: commandFn("Stderr!", func(ps *env.ProgramState, c *command, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			out, ret := commandOutputFd(ps, c, arg1)
+			if ret != nil {
+				return ret
+			}
+			c.cmd.Stderr = out
+			return arg0
+		}),
+	},
+	// Tests:
+	// equal { cmd { echo -n Hello World } |Pipe cmd { tr a-z A-Z } |Output } "HELLO WORLD"
+	// Args:
+	// * c1: first command writing to the pipe
+	// * c2: second command reading from the pipe
+	// Returns:
+	// * new native command object
+	"command//Pipe": {
+		Argsn: 2,
+		Doc:   "Pipe the output of the first command to the input of the second command.",
+		Fn: commandFn("Pipe", func(ps *env.ProgramState, c *command, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			switch it := arg1.(type) {
+			case env.Native:
+				if c2, ok := it.Value.(*command); ok {
+					return *env.NewNative(ps.Idx, pipeCommands(c, c2), "command")
+				} else {
+					return MakeBuiltinError(ps, "arg1 must be of kind command", "Pipe!")
+				}
+			default:
+				return MakeArgError(ps, 2, []env.Type{env.NativeType}, "Pipe")
+			}
+		}),
+	},
+	// Args:
+	// * command: native command object
+	// Tests:
+	// error { cmd { false } |Run }
+	"command//Run": {
+		Argsn: 1,
+		Doc:   "Start a command and wait for it to finish.",
+		Fn: commandFn("Run", func(ps *env.ProgramState, c *command, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			defer c.Close()
+			err := c.StartPipe()
+			if err != nil {
+				ps.FailureFlag = true
+				return MakeBuiltinError(ps, err.Error(), "Run")
+			}
+			err = c.cmd.Run()
+			if err != nil {
+				ps.FailureFlag = true
+				return MakeBuiltinError(ps, err.Error(), "Run")
+			}
+			return nil
+		}),
+	},
+	// Args:
+	// * command: native command object
+	// Returns:
+	// * for simple command: exit status integer
+	// * for pipeline: list of exit status integers
+	// Tests:
+	// equal { cmd { true } |Status } 0
+	// equal { cmd { false } |Status } 1
+	// equal { cmd { false |true } |Status } list [ 1 0 ]
+	"command//Status": {
+		Argsn: 1,
+		Doc:   "Start a command, wait for it to finish, and return its exit status.",
+		Fn: commandFn("Status", func(ps *env.ProgramState, c *command, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			err := c.StartPipe()
+			if err != nil {
+				c.Close()
+				ps.FailureFlag = true
+				return MakeBuiltinError(ps, err.Error(), "Status")
+			}
+			err = c.cmd.Run()
+			c.Close()
+			status := c.cmd.ProcessState.ExitCode()
+			if err != nil && status == -1 {
+				ps.FailureFlag = true
+				return MakeBuiltinError(ps, err.Error(), "Status")
+			}
+			if len(c.pipe) > 0 {
+				var statusList []any
+				for _, cmd := range c.pipe {
+					statusList = append(statusList, *env.NewInteger(int64(cmd.ProcessState.ExitCode())))
+				}
+				statusList = append(statusList, *env.NewInteger(int64(status)))
+				return *env.NewList(statusList)
+			}
+			return *env.NewInteger(int64(status))
+		}),
+	},
+	// Args:
+	// * command: native command object
+	// Returns:
+	// * string containing data written to the command's standard output
+	"command//Output": {
+		Argsn: 1,
+		Doc:   "Start a command, wait for it to finish, and return its standard output",
+		Fn: commandFn("Output", func(ps *env.ProgramState, c *command, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			defer c.Close()
+			err := c.StartPipe()
+			if err != nil {
+				ps.FailureFlag = true
+				return MakeBuiltinError(ps, err.Error(), "Output")
+			}
+			c.cmd.Stdout = nil
+			out, err := c.cmd.Output()
+			if err != nil {
+				ps.FailureFlag = true
+				return MakeBuiltinError(ps, err.Error(), "Output")
+			}
+			return *env.NewString(string(out))
+		}),
+	},
+	// Args:
+	// * command: native command object
+	// Returns:
+	// * string containing data written to the command's standard output and error
+	"command//CombinedOutput": {
+		Argsn: 1,
+		Doc:   "Start a command, wait for it to finish, and return its combined standard output and error",
+		Fn: commandFn("CombinedOutput", func(ps *env.ProgramState, c *command, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			defer c.Close()
+			err := c.StartPipe()
+			if err != nil {
+				ps.FailureFlag = true
+				return MakeBuiltinError(ps, err.Error(), "CombinedOutput")
+			}
+			c.cmd.Stdout = nil
+			c.cmd.Stderr = nil
+			out, err := c.cmd.CombinedOutput()
+			if err != nil {
+				ps.FailureFlag = true
+				return MakeBuiltinError(ps, err.Error(), "CombinedOutput")
+			}
+			return *env.NewString(string(out))
+		}),
+	},
+}

--- a/evaldo/builtins_io.go
+++ b/evaldo/builtins_io.go
@@ -232,6 +232,18 @@ var Builtins_io = map[string]*env.Builtin{
 			return *env.NewNative(env1.Idx, os.Stdout, "writer")
 		},
 	},
+	//
+	// Args:
+	// * none
+	// Returns:
+	// * native writer object connected to standard error
+	"stderr": {
+		Argsn: 0,
+		Doc:   "Gets a writer for standard error.",
+		Fn: func(env1 *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
+			return *env.NewNative(env1.Idx, os.Stderr, "writer")
+		},
+	},
 
 	// TODO: add scanner ScanString method ... look at: https://stackoverflow.com/questions/47479564/go-bufio-readstring-in-loop-is-infinite
 

--- a/info/io.html
+++ b/info/io.html
@@ -103,6 +103,11 @@
 <p class='returns'><b>returns</b> native writer object connected to standard output</p>
 <div class='group'>
 </div>
+<h3>stderr</h3><p>Gets a writer for standard error.</p>
+<p class='arg'>none</p>
+<p class='returns'><b>returns</b> native writer object connected to standard error</p>
+<div class='group'>
+</div>
 <h3>reader//Read\string</h3><p>Reads all content from a reader as a string.</p>
 <p class='arg'><b>reader</b> native reader object</p>
 <p class='returns'><b>returns</b> string containing all content from the reader</p>
@@ -320,6 +325,83 @@
 <h3>tail-file//Close</h3><p>Closes a tailed file, stopping the monitoring.</p>
 <p class='arg'><b>tail</b> native tail-file object</p>
 <p class='returns'><b>returns</b> empty string if successful</p>
+<div class='group'>
+</div>
+</div>
+<h2>Command Operations </h2><p>Running other programs</p><div class='section'>
+<h3>cmd</h3><p>Create a command.</p>
+<p class='arg'><b>command</b> block or list containing a command arguments</p>
+<p class='returns'><b>returns</b> native command object</p>
+<div class='group'>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>cmd { echo -n Hello World } |Output
+; returns "Hello World"</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>cmd { echo -n Hello World |tr A-Z a-z |sed "s/hello/goodbye/" } |Output
+; returns "goodbye world"</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>cmd { echo -n "1 + 1 =" { 1 + 1 } } |Output
+; returns "1 + 1 = 2"</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>args: list { "two" "arguments" } cmd { printf "'%s' " ?args } |Output
+; returns "'two' 'arguments' "</code></pre>
+</div>
+<h3>command//Dir!</h3><p>Change the working directory of a command.</p>
+<p class='arg'><b>command</b> native command object</p>
+<p class='arg'><b>dir</b> path to the working directory</p>
+<p class='returns'><b>returns</b> the original command object</p>
+<div class='group'>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>cmd { pwd } |Dir! %/ |Output |trim
+; returns "/"</code></pre>
+</div>
+<h3>command//Stdin!</h3><p>Change the standard input of a command.</p>
+<p class='arg'><b>command</b> native command object</p>
+<p class='arg'><b>input</b> path to an input file, a native file object, or a reader</p>
+<p class='returns'><b>returns</b> the original command object</p>
+<div class='group'>
+</div>
+<h3>command//Stdout!</h3><p>Change the standard output of a command.</p>
+<p class='arg'><b>command</b> native command object</p>
+<p class='arg'><b>output</b> path to an output file, a native file object, or a writer</p>
+<p class='returns'><b>returns</b> the original command object</p>
+<div class='group'>
+</div>
+<h3>command//Stderr!</h3><p>Change the standard error of a command.</p>
+<p class='arg'><b>command</b> native command object</p>
+<p class='arg'><b>output</b> path to an output file, a native file object, or a writer</p>
+<p class='returns'><b>returns</b> the original command object</p>
+<div class='group'>
+</div>
+<h3>command//Pipe</h3><p>Pipe the output of the first command to the input of the second command.</p>
+<p class='arg'><b>c1</b> first command writing to the pipe</p>
+<p class='arg'><b>c2</b> second command reading from the pipe</p>
+<p class='returns'><b>returns</b> new native command object</p>
+<div class='group'>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>cmd { echo -n Hello World } |Pipe cmd { tr a-z A-Z } |Output
+; returns "HELLO WORLD"</code></pre>
+</div>
+<h3>command//Run</h3><p>Start a command and wait for it to finish.</p>
+<p class='arg'><b>command</b> native command object</p>
+<div class='group'>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>cmd { false } |Run
+; correctly causes error:
+; exit status 1 in builtin Run. </code></pre>
+</div>
+<h3>command//Status</h3><p>Start a command, wait for it to finish, and return its exit status.</p>
+<p class='arg'><b>command</b> native command object</p>
+<p class='returns'><b>returns</b> for simple command: exit status integerfor pipeline: list of exit status integers</p>
+<div class='group'>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>cmd { true } |Status
+; returns 0</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>cmd { false } |Status
+; returns 1</code></pre>
+<pre class='prettyprint lang-rye'><code language='lang-rye'>cmd { false |true } |Status
+; returns list { 1 0 }</code></pre>
+</div>
+<h3>command//Output</h3><p>Start a command, wait for it to finish, and return its standard output</p>
+<p class='arg'><b>command</b> native command object</p>
+<p class='returns'><b>returns</b> string containing data written to the command's standard output</p>
+<div class='group'>
+</div>
+<h3>command//CombinedOutput</h3><p>Start a command, wait for it to finish, and return its combined standard output and error</p>
+<p class='arg'><b>command</b> native command object</p>
+<p class='returns'><b>returns</b> string containing data written to the command's standard output and error</p>
 <div class='group'>
 </div>
 </div>

--- a/info/io.info.rye
+++ b/info/io.info.rye
@@ -94,6 +94,16 @@ section "File Operations " "File system operations and file manipulation" {
 	{
 	}
 
+	group "stderr" 
+	"Gets a writer for standard error."
+	{
+		arg `none`
+		returns `native writer object connected to standard error`
+	}
+
+	{
+	}
+
 	group "reader//Read\\string" 
 	"Reads all content from a reader as a string."
 	{
@@ -462,6 +472,123 @@ section "File Monitoring " "File watching and tailing operations" {
 	{
 		arg `tail: native tail-file object`
 		returns `empty string if successful`
+	}
+
+	{
+	}
+
+}
+
+section "Command Operations " "Running other programs" {
+	group "cmd" 
+	"Create a command."
+	{
+		arg `command: block or list containing a command arguments`
+		returns `native command object`
+	}
+
+	{
+		equal { cmd { echo -n Hello World } |Output } "Hello World"
+		equal { cmd { echo -n Hello World |tr A-Z a-z |sed "s/hello/goodbye/" } |Output } "goodbye world"
+		equal { cmd { echo -n "1 + 1 =" { 1 + 1 } } |Output } "1 + 1 = 2"
+		equal { args: list { "two" "arguments" } cmd { printf "'%s' " ?args } |Output } "'two' 'arguments' "
+	}
+
+	group "command//Dir!" 
+	"Change the working directory of a command."
+	{
+		arg `command: native command object`
+		arg `dir: path to the working directory`
+		returns `the original command object`
+	}
+
+	{
+		equal { cmd { pwd } |Dir! %/ |Output |trim } "/"
+	}
+
+	group "command//Stdin!" 
+	"Change the standard input of a command."
+	{
+		arg `command: native command object`
+		arg `input: path to an input file, a native file object, or a reader`
+		returns `the original command object`
+	}
+
+	{
+	}
+
+	group "command//Stdout!" 
+	"Change the standard output of a command."
+	{
+		arg `command: native command object`
+		arg `output: path to an output file, a native file object, or a writer`
+		returns `the original command object`
+	}
+
+	{
+	}
+
+	group "command//Stderr!" 
+	"Change the standard error of a command."
+	{
+		arg `command: native command object`
+		arg `output: path to an output file, a native file object, or a writer`
+		returns `the original command object`
+	}
+
+	{
+	}
+
+	group "command//Pipe" 
+	"Pipe the output of the first command to the input of the second command."
+	{
+		arg `c1: first command writing to the pipe`
+		arg `c2: second command reading from the pipe`
+		returns `new native command object`
+	}
+
+	{
+		equal { cmd { echo -n Hello World } |Pipe cmd { tr a-z A-Z } |Output } "HELLO WORLD"
+	}
+
+	group "command//Run" 
+	"Start a command and wait for it to finish."
+	{
+		arg `command: native command object`
+	}
+
+	{
+		error { cmd { false } |Run }
+	}
+
+	group "command//Status" 
+	"Start a command, wait for it to finish, and return its exit status."
+	{
+		arg `command: native command object`
+		returns `for simple command: exit status integerfor pipeline: list of exit status integers`
+	}
+
+	{
+		equal { cmd { true } |Status } 0
+		equal { cmd { false } |Status } 1
+		equal { cmd { false |true } |Status } list [ 1 0 ]
+	}
+
+	group "command//Output" 
+	"Start a command, wait for it to finish, and return its standard output"
+	{
+		arg `command: native command object`
+		returns `string containing data written to the command's standard output`
+	}
+
+	{
+	}
+
+	group "command//CombinedOutput" 
+	"Start a command, wait for it to finish, and return its combined standard output and error"
+	{
+		arg `command: native command object`
+		returns `string containing data written to the command's standard output and error`
 	}
 
 	{

--- a/info/regen
+++ b/info/regen
@@ -17,6 +17,7 @@
 ../cmd/rbit/rbit ../evaldo/builtins_sxml.go >> formats.info.rye
 ../cmd/rbit/rbit ../evaldo/builtins_html.go >> formats.info.rye
 ../cmd/rbit/rbit ../evaldo/builtins_io.go > io.info.rye
+../cmd/rbit/rbit ../evaldo/builtins_cmd.go >> io.info.rye
 ../cmd/rbit/rbit ../evaldo/builtins_sqlite.go >> io.info.rye
  ../cmd/rbit/rbit ../evaldo/builtins_psql.go >> io.info.rye
 # ../cmd/rbit/rbit ../evaldo/builtins_mysql.go >> io.info.rye


### PR DESCRIPTION
I implemented some ideas I had towards #661. It doesn't implement any of the complex stuff yet, but might provide a starting point for an easy-to-use API for running external processes.

At the core, I implemented `sh`, which builds a command from a Rye block, plus some functions for manipulating and running the command. It can be used as follows:

```
; basic command, capturing output
sh { echo -n Hello World } |Output
; -> "Hello World"

; parameters from Rye values
arg: "Hello World"
args: list { "two" "arguments" }
sh { printf "'%s' " { arg } { args } } |Output
; -> "'Hello World' 'two' 'arguments' "

; Unix pipes
sh { echo -n Hello World |tr A-Z a-z |sed "s/hello/goodbye/" } |Output
; -> "goodbye world"

; redirect output to file
sh { echo Write to file } |Stdout! %/tmp/file |Run
Open %/tmp/file |Read-all |trim
; -> "Write to file"

; Change working directory
sh { pwd } |Dir! %/tmp |Output |trim
; -> "/tmp"
```

The implementation is just a proof-of-concept and there is a lot of stuff missing, like:
- proper error handling
- all functions on `exec.Cmd`, including those for the use-cases in #661 
  - It would be cool if we could somehow integrate Rye code into a pipeline, without needing to capture the whole output. Not sure what an API for this would look like, though.
- some oddities in the parsing (why is `-n` a pipeword?)

Let me know what you think. I'm happy to continue working on this if you like the idea.